### PR TITLE
fix(windows): run the about dialog in its own thread, closes #57

### DIFF
--- a/.changes/windows-about-menu-item.md
+++ b/.changes/windows-about-menu-item.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+On Windows, fix panic when click a menu item while the `PredefinedMenuItem::about` dialog is open.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1154,7 +1154,14 @@ unsafe extern "system" fn menu_subclass_proc(
                                 "About {}",
                                 metadata.name.as_deref().unwrap_or_default()
                             ));
-                            MessageBoxW(hwnd, message.as_ptr(), title.as_ptr(), MB_ICONINFORMATION);
+                            std::thread::spawn(move || {
+                                MessageBoxW(
+                                    hwnd,
+                                    message.as_ptr(),
+                                    title.as_ptr(),
+                                    MB_ICONINFORMATION,
+                                );
+                            });
                         }
 
                         _ => {}


### PR DESCRIPTION
fix #57