### PR TITLE
support `AboutMetadata` on macos

### DIFF
--- a/.changes/macos-about-metadata.md
+++ b/.changes/macos-about-metadata.md
@@ -1,0 +1,5 @@
+---
+"muda": minor
+---
+
+Add support for `AboutMetadata` on macOS

--- a/src/platform_impl/gtk/icon.rs
+++ b/src/platform_impl/gtk/icon.rs
@@ -45,7 +45,7 @@ impl PlatformIcon {
         })
     }
 
-    pub fn to_pixbuf(&self, w: i32, h: i32) -> Pixbuf {
+    pub fn to_pixbuf(&self) -> Pixbuf {
         Pixbuf::from_mut_slice(
             self.raw.clone(),
             gdk_pixbuf::Colorspace::Rgb,
@@ -55,7 +55,11 @@ impl PlatformIcon {
             self.height,
             self.row_stride,
         )
-        .scale_simple(w, h, gdk_pixbuf::InterpType::Bilinear)
-        .unwrap()
+    }
+
+    pub fn to_pixbuf_scale(&self, w: i32, h: i32) -> Pixbuf {
+        self.to_pixbuf()
+            .scale_simple(w, h, gdk_pixbuf::InterpType::Bilinear)
+            .unwrap()
     }
 }

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -964,7 +964,7 @@ impl PredefinedMenuItem {
                         if let Some(name) = &metadata.name {
                             builder = builder.program_name(name);
                         }
-                        if let Some(version) = &metadata.version {
+                        if let Some(version) = &metadata.full_version() {
                             builder = builder.version(version);
                         }
                         if let Some(authors) = &metadata.authors {

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -171,7 +171,7 @@ impl MenuChild {
     fn set_icon(&mut self, icon: Option<Icon>) {
         self.icon = icon.clone();
 
-        let pixbuf = icon.map(|i| i.inner.to_pixbuf(16, 16));
+        let pixbuf = icon.map(|i| i.inner.to_pixbuf_scale(16, 16));
         for items in self.gtk_menu_items.values() {
             for i in items {
                 let box_container = i.child().unwrap().downcast::<gtk::Box>().unwrap();
@@ -985,6 +985,9 @@ impl PredefinedMenuItem {
                         if let Some(website_label) = &metadata.website_label {
                             builder = builder.website_label(website_label);
                         }
+                        if let Some(icon) = &metadata.icon {
+                            builder = builder.icon(&icon.inner.to_pixbuf());
+                        }
 
                         let about = builder.build();
                         about.run();
@@ -1177,7 +1180,7 @@ impl IconMenuItem {
         let image = self_
             .icon
             .as_ref()
-            .map(|i| gtk::Image::from_pixbuf(Some(&i.inner.to_pixbuf(16, 16))))
+            .map(|i| gtk::Image::from_pixbuf(Some(&i.inner.to_pixbuf_scale(16, 16))))
             .unwrap_or_else(gtk::Image::default);
 
         self_.accel_group = accel_group.cloned();

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -986,7 +986,7 @@ impl PredefinedMenuItem {
                             builder = builder.website_label(website_label);
                         }
                         if let Some(icon) = &metadata.icon {
-                            builder = builder.icon(&icon.inner.to_pixbuf());
+                            builder = builder.logo(&icon.inner.to_pixbuf());
                         }
 
                         let about = builder.build();

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -653,8 +653,8 @@ impl PredefinedMenuItem {
             _ => create_ns_menu_item(&child.text, item_type.selector(), &child.accelerator),
         };
 
-        unsafe {
-            if let PredfinedMenuItemType::About(_) = child.predefined_item_type {
+        if let PredfinedMenuItemType::About(_) = child.predefined_item_type {
+            unsafe {
                 let _: () = msg_send![ns_menu_item, setTarget: ns_menu_item];
                 let _: () = msg_send![ns_menu_item, setTag:child.id()];
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -1009,61 +1009,61 @@ extern "C" fn fire_menu_item_click(this: &Object, _: Sel, _item: id) {
         let ptr: usize = *this.get_ivar(BLOCK_PTR);
         let item = ptr as *mut &mut MenuChild;
 
-        match &(*item).predefined_item_type {
-            PredfinedMenuItemType::About(Some(about_meta)) => {
-                unsafe fn mkstr(s: &str) -> id {
-                    NSString::alloc(nil).init_str(s)
+        if let PredfinedMenuItemType::About(about_meta) = &(*item).predefined_item_type {
+            match about_meta {
+                Some(about_meta) => {
+                    unsafe fn mkstr(s: &str) -> id {
+                        NSString::alloc(nil).init_str(s)
+                    }
+
+                    let mut keys: Vec<id> = Default::default();
+                    let mut objects: Vec<id> = Default::default();
+
+                    if let Some(name) = &about_meta.name {
+                        keys.push(NSAboutPanelOptionApplicationName);
+                        objects.push(mkstr(&name));
+                    }
+
+                    if let Some(version) = &about_meta.version {
+                        keys.push(NSAboutPanelOptionApplicationVersion);
+                        objects.push(mkstr(&version));
+                    }
+
+                    if let Some(short_version) = &about_meta.short_version {
+                        keys.push(NSAboutPanelOptionVersion);
+                        objects.push(mkstr(&short_version));
+                    }
+
+                    if let Some(copyright) = &about_meta.copyright {
+                        keys.push(NSString::alloc(nil).init_str("Copyright"));
+                        objects.push(mkstr(&copyright));
+                    }
+
+                    if let Some(icon) = &about_meta.icon {
+                        keys.push(NSAboutPanelOptionApplicationIcon);
+                        objects.push(icon.inner.to_nsimage(None));
+                    }
+
+                    if let Some(credits) = &about_meta.credits {
+                        keys.push(NSAboutPanelOptionCredits);
+                        let attributed_str: id = msg_send![class!(NSAttributedString), alloc];
+                        let _: () = msg_send![attributed_str, initWithString: mkstr(&credits)];
+                        objects.push(attributed_str);
+                    }
+
+                    let keys_array = NSArray::arrayWithObjects(nil, &keys);
+                    let objs_array = NSArray::arrayWithObjects(nil, &objects);
+
+                    let dict =
+                        NSDictionary::dictionaryWithObjects_forKeys_(nil, objs_array, keys_array);
+
+                    let _: () = msg_send![NSApp(), orderFrontStandardAboutPanelWithOptions: dict];
                 }
 
-                let mut keys: Vec<id> = Default::default();
-                let mut objects: Vec<id> = Default::default();
-
-                if let Some(name) = &about_meta.name {
-                    keys.push(NSAboutPanelOptionApplicationName);
-                    objects.push(mkstr(&name));
+                None => {
+                    let _: () = msg_send![NSApp(), orderFrontStandardAboutPanel: this];
                 }
-
-                if let Some(version) = &about_meta.version {
-                    keys.push(NSAboutPanelOptionApplicationVersion);
-                    objects.push(mkstr(&version));
-                }
-
-                if let Some(short_version) = &about_meta.short_version {
-                    keys.push(NSAboutPanelOptionVersion);
-                    objects.push(mkstr(&short_version));
-                }
-
-                if let Some(copyright) = &about_meta.copyright {
-                    keys.push(NSString::alloc(nil).init_str("Copyright"));
-                    objects.push(mkstr(&copyright));
-                }
-
-                if let Some(icon) = &about_meta.icon {
-                    keys.push(NSAboutPanelOptionApplicationIcon);
-                    objects.push(icon.inner.to_nsimage(None));
-                }
-
-                if let Some(credits) = &about_meta.credits {
-                    keys.push(NSAboutPanelOptionCredits);
-                    let attributed_str: id = msg_send![class!(NSAttributedString), alloc];
-                    let _: () = msg_send![attributed_str, initWithString: mkstr(&credits)];
-                    objects.push(attributed_str);
-                }
-
-                let keys_array = NSArray::arrayWithObjects(nil, &keys);
-                let objs_array = NSArray::arrayWithObjects(nil, &objects);
-
-                let dict =
-                    NSDictionary::dictionaryWithObjects_forKeys_(nil, objs_array, keys_array);
-
-                let _: () = msg_send![NSApp(), orderFrontStandardAboutPanelWithOptions: dict];
             }
-
-            PredfinedMenuItemType::About(None) => {
-                let _: () = msg_send![NSApp(), orderFrontStandardAboutPanel: this];
-            }
-
-            _ => {}
         }
 
         if (*item).type_ == MenuItemType::Check {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -41,6 +41,10 @@ extern "C" {
     static NSAboutPanelOptionVersion: id;
 }
 
+/// https://developer.apple.com/documentation/appkit/nsapplication/1428479-orderfrontstandardaboutpanelwith#discussion
+#[allow(non_upper_case_globals)]
+const NSAboutPanelOptionCopyright: &str = "Copyright";
+
 /// A generic child in a menu
 ///
 /// Be careful when cloning this item and treat it as read-only
@@ -1035,7 +1039,7 @@ extern "C" fn fire_menu_item_click(this: &Object, _: Sel, _item: id) {
                     }
 
                     if let Some(copyright) = &about_meta.copyright {
-                        keys.push(NSString::alloc(nil).init_str("Copyright"));
+                        keys.push(mkstr(NSAboutPanelOptionCopyright));
                         objects.push(mkstr(&copyright));
                     }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -11,9 +11,9 @@ pub(crate) use icon::PlatformIcon;
 use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Once};
 
 use cocoa::{
-    appkit::{CGFloat, NSApp, NSApplication, NSEventModifierFlags, NSImage, NSMenu, NSMenuItem},
+    appkit::{CGFloat, NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem},
     base::{id, nil, selector, NO, YES},
-    foundation::{NSAutoreleasePool, NSData, NSInteger, NSPoint, NSRect, NSSize, NSString},
+    foundation::{NSArray, NSAutoreleasePool, NSDictionary, NSInteger, NSPoint, NSRect, NSString},
 };
 use objc::{
     declare::ClassDecl,
@@ -31,6 +31,15 @@ use crate::{
 
 static COUNTER: Counter = Counter::new();
 static BLOCK_PTR: &str = "mudaMenuItemBlockPtr";
+
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {
+    static NSAboutPanelOptionApplicationName: id;
+    static NSAboutPanelOptionApplicationIcon: id;
+    static NSAboutPanelOptionApplicationVersion: id;
+    static NSAboutPanelOptionCredits: id;
+    static NSAboutPanelOptionVersion: id;
+}
 
 /// A generic child in a menu
 ///
@@ -641,10 +650,21 @@ impl PredefinedMenuItem {
         };
 
         unsafe {
+            if let PredfinedMenuItemType::About(_) = child.predefined_item_type {
+                let _: () = msg_send![ns_menu_item, setTarget: ns_menu_item];
+                let _: () = msg_send![ns_menu_item, setTag:child.id()];
+
+                // Store a raw pointer to the `MenuChild` as an instance variable on the native menu item
+                let ptr = Box::into_raw(Box::new(&*child));
+                (*ns_menu_item).set_ivar(BLOCK_PTR, ptr as usize);
+            }
+        }
+
+        unsafe {
             if !child.enabled {
                 let () = msg_send![ns_menu_item, setEnabled: NO];
             }
-            if child.predefined_item_type == PredfinedMenuItemType::Services {
+            if let PredfinedMenuItemType::Services = child.predefined_item_type {
                 // we have to assign an empty menu as the app's services menu, and macOS will populate it
                 let services_menu = NSMenu::new(nil).autorelease();
                 let () = msg_send![NSApp(), setServicesMenu: services_menu];
@@ -858,7 +878,8 @@ impl PredfinedMenuItemType {
             PredfinedMenuItemType::ShowAll => Some(selector("unhideAllApplications:")),
             PredfinedMenuItemType::CloseWindow => Some(selector("performClose:")),
             PredfinedMenuItemType::Quit => Some(selector("terminate:")),
-            PredfinedMenuItemType::About(_) => Some(selector("orderFrontStandardAboutPanel:")),
+            // manual implementation in `fire_menu_item_click`
+            PredfinedMenuItemType::About(_) => Some(selector("fireMenuItemAction:")),
             PredfinedMenuItemType::Services => None,
             PredfinedMenuItemType::None => None,
         }
@@ -988,6 +1009,63 @@ extern "C" fn fire_menu_item_click(this: &Object, _: Sel, _item: id) {
         let ptr: usize = *this.get_ivar(BLOCK_PTR);
         let item = ptr as *mut &mut MenuChild;
 
+        match &(*item).predefined_item_type {
+            PredfinedMenuItemType::About(Some(about_meta)) => {
+                unsafe fn mkstr(s: &str) -> id {
+                    NSString::alloc(nil).init_str(s)
+                }
+
+                let mut keys: Vec<id> = Default::default();
+                let mut objects: Vec<id> = Default::default();
+
+                if let Some(name) = &about_meta.name {
+                    keys.push(NSAboutPanelOptionApplicationName);
+                    objects.push(mkstr(&name));
+                }
+
+                if let Some(version) = &about_meta.version {
+                    keys.push(NSAboutPanelOptionApplicationVersion);
+                    objects.push(mkstr(&version));
+                }
+
+                if let Some(short_version) = &about_meta.short_version {
+                    keys.push(NSAboutPanelOptionVersion);
+                    objects.push(mkstr(&short_version));
+                }
+
+                if let Some(copyright) = &about_meta.copyright {
+                    keys.push(NSString::alloc(nil).init_str("Copyright"));
+                    objects.push(mkstr(&copyright));
+                }
+
+                if let Some(icon) = &about_meta.icon {
+                    keys.push(NSAboutPanelOptionApplicationIcon);
+                    objects.push(icon.inner.to_nsimage(None));
+                }
+
+                if let Some(credits) = &about_meta.credits {
+                    keys.push(NSAboutPanelOptionCredits);
+                    let attributed_str: id = msg_send![class!(NSAttributedString), alloc];
+                    let _: () = msg_send![attributed_str, initWithString: mkstr(&credits)];
+                    objects.push(attributed_str);
+                }
+
+                let keys_array = NSArray::arrayWithObjects(nil, &keys);
+                let objs_array = NSArray::arrayWithObjects(nil, &objects);
+
+                let dict =
+                    NSDictionary::dictionaryWithObjects_forKeys_(nil, objs_array, keys_array);
+
+                let _: () = msg_send![NSApp(), orderFrontStandardAboutPanelWithOptions: dict];
+            }
+
+            PredfinedMenuItemType::About(None) => {
+                let _: () = msg_send![NSApp(), orderFrontStandardAboutPanel: this];
+            }
+
+            _ => {}
+        }
+
         if (*item).type_ == MenuItemType::Check {
             (*item).set_checked(!(*item).is_checked());
         }
@@ -1028,22 +1106,8 @@ fn create_ns_menu_item(
 
 fn menuitem_set_icon(menuitem: id, icon: Option<&Icon>) {
     if let Some(icon) = icon {
-        let (width, height) = icon.inner.get_size();
-        let icon = icon.inner.to_png();
-
-        let icon_height: f64 = 18.0;
-        let icon_width: f64 = (width as f64) / (height as f64 / icon_height);
-
         unsafe {
-            let nsdata = NSData::dataWithBytes_length_(
-                nil,
-                icon.as_ptr() as *const std::os::raw::c_void,
-                icon.len() as u64,
-            );
-
-            let nsimage = NSImage::initWithData_(NSImage::alloc(nil), nsdata);
-            let new_size = NSSize::new(icon_width, icon_height);
-            let _: () = msg_send![nsimage, setSize: new_size];
+            let nsimage = icon.inner.to_nsimage(Some(18.));
             let _: () = msg_send![menuitem, setImage: nsimage];
         }
     } else {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -1025,22 +1025,22 @@ extern "C" fn fire_menu_item_click(this: &Object, _: Sel, _item: id) {
 
                     if let Some(name) = &about_meta.name {
                         keys.push(NSAboutPanelOptionApplicationName);
-                        objects.push(mkstr(&name));
+                        objects.push(mkstr(name));
                     }
 
                     if let Some(version) = &about_meta.version {
                         keys.push(NSAboutPanelOptionApplicationVersion);
-                        objects.push(mkstr(&version));
+                        objects.push(mkstr(version));
                     }
 
                     if let Some(short_version) = &about_meta.short_version {
                         keys.push(NSAboutPanelOptionVersion);
-                        objects.push(mkstr(&short_version));
+                        objects.push(mkstr(short_version));
                     }
 
                     if let Some(copyright) = &about_meta.copyright {
                         keys.push(mkstr(NSAboutPanelOptionCopyright));
-                        objects.push(mkstr(&copyright));
+                        objects.push(mkstr(copyright));
                     }
 
                     if let Some(icon) = &about_meta.icon {
@@ -1051,7 +1051,7 @@ extern "C" fn fire_menu_item_click(this: &Object, _: Sel, _item: id) {
                     if let Some(credits) = &about_meta.credits {
                         keys.push(NSAboutPanelOptionCredits);
                         let attributed_str: id = msg_send![class!(NSAttributedString), alloc];
-                        let _: () = msg_send![attributed_str, initWithString: mkstr(&credits)];
+                        let _: () = msg_send![attributed_str, initWithString: mkstr(credits)];
                         objects.push(attributed_str);
                     }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1284,7 +1284,7 @@ fn show_about_dialog(hwnd: HWND, metadata: &AboutMetadata) {
         let _ = writeln!(&mut message, "Name: {}", name);
     }
     if let Some(version) = &metadata.full_version() {
-       let _ = writeln!(&mut message, "Version: {}", version);
+        let _ = writeln!(&mut message, "Version: {}", version);
     }
     if let Some(authors) = &metadata.authors {
         let _ = writeln!(&mut message, "Authors: {}", authors.join(", "));

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1166,7 +1166,7 @@ unsafe extern "system" fn menu_subclass_proc(
                             if let Some(name) = &metadata.name {
                                 let _ = writeln!(&mut message, "Name: {}", name);
                             }
-                            if let Some(version) = &metadata.version {
+                            if let Some(version) = &metadata.full_version() {
                                 let _ = writeln!(&mut message, "Version: {}", version);
                             }
                             if let Some(authors) = &metadata.authors {

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -194,13 +194,13 @@ pub struct AboutMetadata {
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** This is ignored
+    /// - **macOS:** Unsupported.
     pub authors: Option<Vec<String>>,
     /// Application comments.
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** This is ignored
+    /// - **macOS:** Unsupported.
     pub comments: Option<String>,
     /// The copyright of the application.
     pub copyright: Option<String>,
@@ -208,31 +208,31 @@ pub struct AboutMetadata {
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** This is ignored
+    /// - **macOS:** Unsupported.
     pub license: Option<String>,
     /// The application website.
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** This is ignored
+    /// - **macOS:** Unsupported.
     pub website: Option<String>,
     /// The website label.
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** This is ignored
+    /// - **macOS:** Unsupported.
     pub website_label: Option<String>,
     /// The credits.
     ///
     /// ## Platform-specific
     ///
-    /// - **Windows / Linux:** This is ignored
+    /// - **Windows / Linux:** Unsupported.
     pub credits: Option<String>,
     /// The application icon.
     ///
     /// ## Platform-specific
     ///
-    /// - **Windows / Linux:** This is ignored
+    /// - **Windows:** Unsupported.
     pub icon: Option<Icon>,
 }
 

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -280,6 +280,7 @@ fn test_about_metadata() {
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum PredfinedMenuItemType {
     Separator,
     Copy,

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -188,7 +188,7 @@ pub struct AboutMetadata {
     ///
     /// ## Platform-specific
     ///
-    /// - **Windows / Linux:** This is ignored
+    /// - **Windows / Linux:** Appended to the end of `version` in parentheses
     pub short_version: Option<String>,
     /// The authors of the application.
     ///
@@ -234,6 +234,48 @@ pub struct AboutMetadata {
     ///
     /// - **Windows / Linux:** This is ignored
     pub icon: Option<Icon>,
+}
+
+impl AboutMetadata {
+    pub(crate) fn full_version(&self) -> Option<String> {
+        Some(format!(
+            "{}{}",
+            (self.version.as_ref())?,
+            (self.short_version.as_ref())
+                .map(|v| format!(" ({v})"))
+                .unwrap_or_default()
+        ))
+    }
+}
+
+#[test]
+fn test_about_metadata() {
+    assert_eq!(
+        AboutMetadata {
+            ..Default::default()
+        }
+        .full_version(),
+        None
+    );
+
+    assert_eq!(
+        AboutMetadata {
+            version: Some("Version: 1.0".into()),
+            ..Default::default()
+        }
+        .full_version(),
+        Some("Version: 1.0".into())
+    );
+
+    assert_eq!(
+        AboutMetadata {
+            version: Some("Version: 1.0".into()),
+            short_version: Some("Universal".into()),
+            ..Default::default()
+        }
+        .full_version(),
+        Some("Version: 1.0 (Universal)".into())
+    );
 }
 
 #[derive(Debug, Clone)]

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{accelerator::Accelerator, MenuItemExt, MenuItemType};
+use crate::{accelerator::Accelerator, icon::Icon, MenuItemExt, MenuItemType};
 use keyboard_types::{Code, Modifiers};
 
 #[cfg(target_os = "macos")]
@@ -178,31 +178,69 @@ impl PredefinedMenuItem {
 }
 
 /// Application metadata for the [`PredefinedMenuItem::about`].
-///
-/// ## Platform-specific
-///
-/// - **macOS:** The metadata is ignored.
-#[derive(PartialEq, Eq, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct AboutMetadata {
     /// The application name.
     pub name: Option<String>,
     /// The application version.
     pub version: Option<String>,
+    /// The short version, e.g. "1.0"
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Windows / Linux:** This is ignored
+    pub short_version: Option<String>,
     /// The authors of the application.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is ignored
     pub authors: Option<Vec<String>>,
     /// Application comments.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is ignored
     pub comments: Option<String>,
     /// The copyright of the application.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is ignored
     pub copyright: Option<String>,
     /// The license of the application.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is ignored
     pub license: Option<String>,
     /// The application website.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is ignored
     pub website: Option<String>,
     /// The website label.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is ignored
     pub website_label: Option<String>,
+    /// The credits.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Windows / Linux:** This is ignored
+    pub credits: Option<String>,
+    /// The application icon.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Windows / Linux:** This is ignored
+    pub icon: Option<Icon>,
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub(crate) enum PredfinedMenuItemType {
     Separator,

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -184,11 +184,11 @@ pub struct AboutMetadata {
     pub name: Option<String>,
     /// The application version.
     pub version: Option<String>,
-    /// The short version, e.g. "1.0"
+    /// The short version, e.g. "1.0".
     ///
     /// ## Platform-specific
     ///
-    /// - **Windows / Linux:** Appended to the end of `version` in parentheses
+    /// - **Windows / Linux:** Appended to the end of `version` in parentheses.
     pub short_version: Option<String>,
     /// The authors of the application.
     ///

--- a/src/predefined.rs
+++ b/src/predefined.rs
@@ -203,10 +203,6 @@ pub struct AboutMetadata {
     /// - **macOS:** This is ignored
     pub comments: Option<String>,
     /// The copyright of the application.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **macOS:** This is ignored
     pub copyright: Option<String>,
     /// The license of the application.
     ///


### PR DESCRIPTION
Passes `AboutMetadata` to the About predefined menu type. Data is passed through to `orderFrontStandardAboutPanelWithOptions`.

I had to introduce a few new fields to support e.g. `NSAboutPanelOptionApplicationIcon`.