### PR TITLE
fix(windows): don't drop `Menu` or `MenuChild` inside menu proc

### DIFF
--- a/.changes/destroy.md
+++ b/.changes/destroy.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+On Windows, fix `ContextMenu::detach_menu_subclass_from_hwnd` crashing and terminating the thread.


### PR DESCRIPTION
`Menu` or `MenuChild`  are not owned by the menu proc and so it shouldn't drop it, previously this was okay because the `Menu` pr `MenuChild` used to be a wrapper around `Rc<RefCell>` but that was changed in the last release.