### PR TITLE
refactor: remove unnecessary `Rc` usages

### DIFF
--- a/src/items/check.rs
+++ b/src/items/check.rs
@@ -14,7 +14,7 @@ use crate::{accelerator::Accelerator, IsMenuItem, MenuId, MenuItemKind};
 /// [`Submenu`]: crate::Submenu
 #[derive(Clone)]
 pub struct CheckMenuItem {
-    pub(crate) id: Rc<MenuId>,
+    pub(crate) id: MenuId,
     pub(crate) inner: Rc<RefCell<crate::platform_impl::MenuChild>>,
 }
 
@@ -47,7 +47,7 @@ impl CheckMenuItem {
             None,
         );
         Self {
-            id: Rc::new(item.id().clone()),
+            id: item.id().clone(),
             inner: Rc::new(RefCell::new(item)),
         }
     }
@@ -65,7 +65,7 @@ impl CheckMenuItem {
     ) -> Self {
         let id = id.into();
         Self {
-            id: Rc::new(id.clone()),
+            id: id.clone(),
             inner: Rc::new(RefCell::new(crate::platform_impl::MenuChild::new_check(
                 text.as_ref(),
                 enabled,

--- a/src/items/icon.rs
+++ b/src/items/icon.rs
@@ -17,7 +17,7 @@ use crate::{
 /// [`Submenu`]: crate::Submenu
 #[derive(Clone)]
 pub struct IconMenuItem {
-    pub(crate) id: Rc<MenuId>,
+    pub(crate) id: MenuId,
     pub(crate) inner: Rc<RefCell<crate::platform_impl::MenuChild>>,
 }
 
@@ -50,7 +50,7 @@ impl IconMenuItem {
             None,
         );
         Self {
-            id: Rc::new(item.id().clone()),
+            id: item.id().clone(),
             inner: Rc::new(RefCell::new(item)),
         }
     }
@@ -68,7 +68,7 @@ impl IconMenuItem {
     ) -> Self {
         let id = id.into();
         Self {
-            id: Rc::new(id.clone()),
+            id: id.clone(),
             inner: Rc::new(RefCell::new(crate::platform_impl::MenuChild::new_icon(
                 text.as_ref(),
                 enabled,
@@ -100,7 +100,7 @@ impl IconMenuItem {
             None,
         );
         Self {
-            id: Rc::new(item.id().clone()),
+            id: item.id().clone(),
             inner: Rc::new(RefCell::new(item)),
         }
     }
@@ -121,7 +121,7 @@ impl IconMenuItem {
     ) -> Self {
         let id = id.into();
         Self {
-            id: Rc::new(id.clone()),
+            id: id.clone(),
             inner: Rc::new(RefCell::new(
                 crate::platform_impl::MenuChild::new_native_icon(
                     text.as_ref(),

--- a/src/items/normal.rs
+++ b/src/items/normal.rs
@@ -8,7 +8,7 @@ use crate::{accelerator::Accelerator, IsMenuItem, MenuId, MenuItemKind};
 /// [`Submenu`]: crate::Submenu
 #[derive(Clone)]
 pub struct MenuItem {
-    pub(crate) id: Rc<MenuId>,
+    pub(crate) id: MenuId,
     pub(crate) inner: Rc<RefCell<crate::platform_impl::MenuChild>>,
 }
 
@@ -30,7 +30,7 @@ impl MenuItem {
     pub fn new<S: AsRef<str>>(text: S, enabled: bool, acccelerator: Option<Accelerator>) -> Self {
         let item = crate::platform_impl::MenuChild::new(text.as_ref(), enabled, acccelerator, None);
         Self {
-            id: Rc::new(item.id().clone()),
+            id: item.id().clone(),
             inner: Rc::new(RefCell::new(item)),
         }
     }
@@ -47,7 +47,7 @@ impl MenuItem {
     ) -> Self {
         let id = id.into();
         Self {
-            id: Rc::new(id.clone()),
+            id: id.clone(),
             inner: Rc::new(RefCell::new(crate::platform_impl::MenuChild::new(
                 text.as_ref(),
                 enabled,

--- a/src/items/predefined.rs
+++ b/src/items/predefined.rs
@@ -13,7 +13,7 @@ use keyboard_types::{Code, Modifiers};
 /// A predefined (native) menu item which has a predfined behavior by the OS or by this crate.
 #[derive(Clone)]
 pub struct PredefinedMenuItem {
-    pub(crate) id: Rc<MenuId>,
+    pub(crate) id: MenuId,
     pub(crate) inner: Rc<RefCell<crate::platform_impl::MenuChild>>,
 }
 
@@ -162,7 +162,7 @@ impl PredefinedMenuItem {
             text.map(|t| t.as_ref().to_string()),
         );
         Self {
-            id: Rc::new(item.id().clone()),
+            id: item.id().clone(),
             inner: Rc::new(RefCell::new(item)),
         }
     }

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -46,31 +46,19 @@ impl MenuChild {
             }
             MenuItemType::MenuItem => {
                 let id = c.borrow().id().clone();
-                MenuItemKind::MenuItem(MenuItem {
-                    id: Rc::new(id),
-                    inner: c,
-                })
+                MenuItemKind::MenuItem(MenuItem { id, inner: c })
             }
             MenuItemType::Predefined => {
                 let id = c.borrow().id().clone();
-                MenuItemKind::Predefined(PredefinedMenuItem {
-                    id: Rc::new(id),
-                    inner: c,
-                })
+                MenuItemKind::Predefined(PredefinedMenuItem { id, inner: c })
             }
             MenuItemType::Check => {
                 let id = c.borrow().id().clone();
-                MenuItemKind::Check(CheckMenuItem {
-                    id: Rc::new(id),
-                    inner: c,
-                })
+                MenuItemKind::Check(CheckMenuItem { id, inner: c })
             }
             MenuItemType::Icon => {
                 let id = c.borrow().id().clone();
-                MenuItemKind::Icon(IconMenuItem {
-                    id: Rc::new(id),
-                    inner: c,
-                })
+                MenuItemKind::Icon(IconMenuItem { id, inner: c })
             }
         }
     }


### PR DESCRIPTION
This PR removes `Rc` containers which are actually unnecessary.

Since `Rc` allocates its content and weak/strong counters on heap, it causes extra heap allocation. And accessing the content checks reference count which is an overhead.

In this crate, contents of `Rc` containers are actually shared by no one. They are always cloned. Such `Rc` containers can be removed safely. This does not introduce any breaking change because the `Rc` containers are implementation details.