### PR TITLE
feat: add `into_id` methods to all menu item types

### DIFF
--- a/.changes/item-into-id.md
+++ b/.changes/item-into-id.md
@@ -2,4 +2,4 @@
 "muda": "patch"
 ---
 
-Added `into_id` methods to `MenuItem`, `CheckMenuItem`, `PredefinedMenuItem`, and `Submenu`. It moves the menu item into its menu ID.
+Added `into_id` method to `MenuItem`, `CheckMenuItem`, `PredefinedMenuItem`, `Submenu`, and `MenuItemKind`. It moves the menu item into its menu ID.

--- a/.changes/item-into-id.md
+++ b/.changes/item-into-id.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+Added `into_id` methods to `MenuItem`, `CheckMenuItem`, `PredefinedMenuItem`, and `Submenu`. It moves the menu item into its menu ID.

--- a/src/items/check.rs
+++ b/src/items/check.rs
@@ -26,15 +26,6 @@ unsafe impl IsMenuItem for CheckMenuItem {
     fn id(&self) -> &MenuId {
         self.id()
     }
-
-    fn into_id(mut self) -> MenuId {
-        // Note: `Rc::into_inner` is available from Rust 1.70
-        if let Some(id) = Rc::get_mut(&mut self.id) {
-            mem::take(id)
-        } else {
-            self.id().clone()
-        }
-    }
 }
 
 impl CheckMenuItem {
@@ -126,13 +117,14 @@ impl CheckMenuItem {
     pub fn set_checked(&self, checked: bool) {
         self.inner.borrow_mut().set_checked(checked)
     }
-}
 
-#[test]
-fn test_from_id_and_into_id() {
-    let id = "TEST ID".to_string();
-    let item = CheckMenuItem::with_id(&id, "test", true, true, None);
-    let expected = MenuId(id);
-    assert_eq!(item.id(), &expected);
-    assert_eq!(item.into_id(), expected);
+    /// Convert this menu item into its menu ID.
+    pub fn into_id(mut self) -> MenuId {
+        // Note: `Rc::into_inner` is available from Rust 1.70
+        if let Some(id) = Rc::get_mut(&mut self.id) {
+            mem::take(id)
+        } else {
+            self.id().clone()
+        }
+    }
 }

--- a/src/items/icon.rs
+++ b/src/items/icon.rs
@@ -29,15 +29,6 @@ unsafe impl IsMenuItem for IconMenuItem {
     fn id(&self) -> &MenuId {
         self.id()
     }
-
-    fn into_id(mut self) -> MenuId {
-        // Note: `Rc::into_inner` is available from Rust 1.70
-        if let Some(id) = Rc::get_mut(&mut self.id) {
-            mem::take(id)
-        } else {
-            self.id().clone()
-        }
-    }
 }
 
 impl IconMenuItem {
@@ -189,13 +180,14 @@ impl IconMenuItem {
         #[cfg(target_os = "macos")]
         self.inner.borrow_mut().set_native_icon(_icon)
     }
-}
 
-#[test]
-fn test_from_id_and_into_id() {
-    let id = "test".to_string();
-    let item = IconMenuItem::with_id(&id, "test", true, None, None);
-    let expected = MenuId(id);
-    assert_eq!(item.id(), &expected);
-    assert_eq!(item.into_id(), expected);
+    /// Convert this menu item into its menu ID.
+    pub fn into_id(mut self) -> MenuId {
+        // Note: `Rc::into_inner` is available from Rust 1.70
+        if let Some(id) = Rc::get_mut(&mut self.id) {
+            mem::take(id)
+        } else {
+            self.id().clone()
+        }
+    }
 }

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -16,7 +16,7 @@ pub use submenu::*;
 
 #[cfg(test)]
 mod test {
-    use crate::{CheckMenuItem, IconMenuItem, MenuId, MenuItem, Submenu};
+    use crate::{CheckMenuItem, IconMenuItem, MenuId, MenuItem, PredefinedMenuItem, Submenu};
 
     #[test]
     fn it_returns_same_id() {
@@ -31,5 +31,30 @@ mod test {
             id,
             IconMenuItem::with_id(id.clone(), "", true, None, None).id()
         );
+    }
+
+    #[test]
+    fn test_convert_from_id_and_into_id() {
+        let id = "TEST ID";
+        let expected = MenuId(id.to_string());
+
+        let item = CheckMenuItem::with_id(id, "test", true, true, None);
+        assert_eq!(item.id(), &expected);
+        assert_eq!(item.into_id(), expected);
+
+        let item = IconMenuItem::with_id(id, "test", true, None, None);
+        assert_eq!(item.id(), &expected);
+        assert_eq!(item.into_id(), expected);
+
+        let item = MenuItem::with_id(id, "test", true, None);
+        assert_eq!(item.id(), &expected);
+        assert_eq!(item.into_id(), expected);
+
+        let item = Submenu::with_id(id, "test", true);
+        assert_eq!(item.id(), &expected);
+        assert_eq!(item.into_id(), expected);
+
+        let item = PredefinedMenuItem::separator();
+        assert_eq!(item.id().clone(), item.into_id());
     }
 }

--- a/src/items/normal.rs
+++ b/src/items/normal.rs
@@ -20,15 +20,6 @@ unsafe impl IsMenuItem for MenuItem {
     fn id(&self) -> &MenuId {
         self.id()
     }
-
-    fn into_id(mut self) -> MenuId {
-        // Note: `Rc::into_inner` is available from Rust 1.70
-        if let Some(id) = Rc::get_mut(&mut self.id) {
-            mem::take(id)
-        } else {
-            self.id().clone()
-        }
-    }
 }
 
 impl MenuItem {
@@ -97,13 +88,14 @@ impl MenuItem {
     pub fn set_accelerator(&self, acccelerator: Option<Accelerator>) -> crate::Result<()> {
         self.inner.borrow_mut().set_accelerator(acccelerator)
     }
-}
 
-#[test]
-fn test_from_id_and_into_id() {
-    let id = "TEST ID".to_string();
-    let item = MenuItem::with_id(&id, "test", true, None);
-    let expected = MenuId(id);
-    assert_eq!(item.id(), &expected);
-    assert_eq!(item.into_id(), expected);
+    /// Convert this menu item into its menu ID.
+    pub fn into_id(mut self) -> MenuId {
+        // Note: `Rc::into_inner` is available from Rust 1.70
+        if let Some(id) = Rc::get_mut(&mut self.id) {
+            mem::take(id)
+        } else {
+            self.id().clone()
+        }
+    }
 }

--- a/src/items/predefined.rs
+++ b/src/items/predefined.rs
@@ -25,15 +25,6 @@ unsafe impl IsMenuItem for PredefinedMenuItem {
     fn id(&self) -> &MenuId {
         self.id()
     }
-
-    fn into_id(mut self) -> MenuId {
-        // Note: `Rc::into_inner` is available from Rust 1.70
-        if let Some(id) = Rc::get_mut(&mut self.id) {
-            mem::take(id)
-        } else {
-            self.id().clone()
-        }
-    }
 }
 
 impl PredefinedMenuItem {
@@ -190,6 +181,16 @@ impl PredefinedMenuItem {
     pub fn set_text<S: AsRef<str>>(&self, text: S) {
         self.inner.borrow_mut().set_text(text.as_ref())
     }
+
+    /// Convert this menu item into its menu ID.
+    pub fn into_id(mut self) -> MenuId {
+        // Note: `Rc::into_inner` is available from Rust 1.70
+        if let Some(id) = Rc::get_mut(&mut self.id) {
+            mem::take(id)
+        } else {
+            self.id().clone()
+        }
+    }
 }
 
 #[test]
@@ -220,13 +221,6 @@ fn test_about_metadata() {
         .full_version(),
         Some("Version: 1.inner (Universal)".into())
     );
-}
-
-#[test]
-fn test_id_and_into_id() {
-    let item = PredefinedMenuItem::separator();
-    let id = item.id().clone();
-    assert_eq!(id, item.into_id());
 }
 
 #[derive(Debug, Clone)]

--- a/src/items/submenu.rs
+++ b/src/items/submenu.rs
@@ -23,15 +23,6 @@ unsafe impl IsMenuItem for Submenu {
     fn id(&self) -> &MenuId {
         self.id()
     }
-
-    fn into_id(mut self) -> MenuId {
-        // Note: `Rc::into_inner` is available from Rust 1.70
-        if let Some(id) = Rc::get_mut(&mut self.id) {
-            mem::take(id)
-        } else {
-            self.id().clone()
-        }
-    }
 }
 
 impl Submenu {
@@ -199,6 +190,16 @@ impl Submenu {
     pub fn set_as_help_menu_for_nsapp(&self) {
         self.inner.borrow_mut().set_as_help_menu_for_nsapp()
     }
+
+    /// Convert this submenu into its menu ID.
+    pub fn into_id(mut self) -> MenuId {
+        // Note: `Rc::into_inner` is available from Rust 1.70
+        if let Some(id) = Rc::get_mut(&mut self.id) {
+            mem::take(id)
+        } else {
+            self.id().clone()
+        }
+    }
 }
 
 impl ContextMenu for Submenu {
@@ -251,13 +252,4 @@ impl ContextMenu for Submenu {
     fn ns_menu(&self) -> *mut std::ffi::c_void {
         self.inner.borrow().ns_menu()
     }
-}
-
-#[test]
-fn test_from_id_and_into_id() {
-    let id = "TEST ID".to_string();
-    let item = Submenu::with_id(&id, "test", true);
-    let expected = MenuId(id);
-    assert_eq!(item.id(), &expected);
-    assert_eq!(item.into_id(), expected);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,8 @@ pub unsafe trait IsMenuItem {
     fn kind(&self) -> MenuItemKind;
 
     fn id(&self) -> &MenuId;
+
+    fn into_id(self) -> MenuId;
 }
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,17 @@ impl MenuItemKind {
             _ => panic!("Not an IconMenuItem"),
         }
     }
+
+    /// Convert this item into its menu ID.
+    pub fn into_id(self) -> MenuId {
+        match self {
+            MenuItemKind::MenuItem(i) => i.into_id(),
+            MenuItemKind::Submenu(i) => i.into_id(),
+            MenuItemKind::Predefined(i) => i.into_id(),
+            MenuItemKind::Check(i) => i.into_id(),
+            MenuItemKind::Icon(i) => i.into_id(),
+        }
+    }
 }
 
 /// A trait that defines a generic item in a menu, which may be one of [`MenuItemKind`]
@@ -256,8 +267,6 @@ pub unsafe trait IsMenuItem {
     fn kind(&self) -> MenuItemKind;
 
     fn id(&self) -> &MenuId;
-
-    fn into_id(self) -> MenuId;
 }
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]


### PR DESCRIPTION
Fixes #111

This PR implements `into_id` methods to `MenuItem`, `CheckMenuItem`, `PredefinedMenuItem`, and `Submenu`. It moves the menu item into its menu ID.

Since I'm not understanding the policy to add a new method to traits, I'm not sure `into_id` method should be added to `IsMenuItem` trait. If it should not, please let me know. I'll update this branch to move the trait methods to normal methods.

I didn't use `Rc::into_inner` because it was added at Rust 1.70 and Tauri's MSRV is earlier than the version.