### PR TITLE
feat: add APIs to build `AboutMetadata` from Cargo package metadata

### DIFF
--- a/.changes/from-cargo-metadata.md
+++ b/.changes/from-cargo-metadata.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+Added `AboutMetadata::from_cargo_metadata` and `AboutMetadataBuilder::with_cargo_metadata` to build the application metadata from Cargo package metadata.


### PR DESCRIPTION
This PR adds `AboutMetadata::from_cargo_metadata` and `AboutMetadataBuilder::with_cargo_metadata` which fill the application metadata using [the Cargo package metadata](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) to make building `AboutMetadata` instance easier.