### PR TITLE
fix(macOS): fixed over release the separator

### DIFF
--- a/.changes/fix-separator-autorelease
+++ b/.changes/fix-separator-autorelease
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+On macOS, fixed autorelease from separator twice.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -733,9 +733,7 @@ impl MenuChild {
     pub fn create_ns_item_for_predefined_menu_item(&mut self, menu_id: u32) -> crate::Result<id> {
         let item_type = self.predefined_item_type.as_ref().unwrap();
         let ns_menu_item = match item_type {
-            PredefinedMenuItemType::Separator => unsafe {
-                NSMenuItem::separatorItem(nil)
-            },
+            PredefinedMenuItemType::Separator => unsafe { NSMenuItem::separatorItem(nil) },
             _ => create_ns_menu_item(&self.text, item_type.selector(), &self.accelerator)?,
         };
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -734,7 +734,7 @@ impl MenuChild {
         let item_type = self.predefined_item_type.as_ref().unwrap();
         let ns_menu_item = match item_type {
             PredefinedMenuItemType::Separator => unsafe {
-                NSMenuItem::separatorItem(nil).autorelease()
+                NSMenuItem::separatorItem(nil)
             },
             _ => create_ns_menu_item(&self.text, item_type.selector(), &self.accelerator)?,
         };


### PR DESCRIPTION
Issue: https://github.com/tauri-apps/tauri/issues/7760

I think the separator is already an autorelease object since we didn't `alloc` and `init` by ourselves. So, calling the `autorelease()` again will cause an over-release and we should not release it manually.