### PR TITLE
fix(macOS): release `ns_submenu`, `ns_menu_item` manually

### DIFF
--- a/.changes/separator-autorelease.md
+++ b/.changes/separator-autorelease.md
@@ -2,4 +2,4 @@
 "muda": patch
 ---
 
-On macOS, fix menu crash due to a double free when using `PredefinedMenuItem::separator`  
+On macOS, fix menu crash due to a double freeing the underlying NsMenu.

--- a/.changes/separator-autorelease.md
+++ b/.changes/separator-autorelease.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On macOS, fix menu crash due to a double free when using `PredefinedMenuItem::separator`  

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -65,7 +65,7 @@ struct NsMenuItemRef(id);
 impl Drop for NsMenuItemRef {
     fn drop(&mut self) {
         unsafe {
-            let _: () = msg_send![self.0, releasse];
+            let _: () = msg_send![self.0, release];
         }
     }
 }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -669,7 +669,9 @@ impl MenuChild {
 
         unsafe {
             ns_menu_item = NSMenuItem::alloc(nil).autorelease();
-            ns_submenu = NSMenu::alloc(nil).autorelease();
+
+            // ns_submenu will be manually released when NsMenuRef dropped
+            ns_submenu = NSMenu::alloc(nil);
 
             let title = NSString::alloc(nil).init_str(&self.text).autorelease();
             let () = msg_send![ns_submenu, setTitle: title];


### PR DESCRIPTION
Issue: https://github.com/tauri-apps/tauri/issues/7828 

The `ns_submenu` will be manually released when `NsMenuRef` dropped.
https://github.com/tauri-apps/muda/blob/fe909ea9cd88cde635dce2bf7894a9f90c80ab04/src/platform_impl/macos/mod.rs#L53-L60

