### PR TITLE
feat(macOS): Add 'Bring All to Front' predefined menu item on macOS

### DIFF
--- a/.changes/bring-all-to-front.md
+++ b/.changes/bring-all-to-front.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+Add `PredefinedMenuItem::bring_all_to_front` for 'Bring All to Front' menu item on macOS.

--- a/.changes/front-menu-item.md
+++ b/.changes/front-menu-item.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+Add `PredefinedMenuItem::front` for 'Bring All to Front' menu item on macOS.

--- a/.changes/front-menu-item.md
+++ b/.changes/front-menu-item.md
@@ -1,5 +1,0 @@
----
-"muda": "patch"
----
-
-Add `PredefinedMenuItem::front` for 'Bring All to Front' menu item on macOS.

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -119,6 +119,7 @@ fn main() {
         &PredefinedMenuItem::maximize(None),
         &PredefinedMenuItem::close_window(Some("Close")),
         &PredefinedMenuItem::fullscreen(None),
+        &PredefinedMenuItem::front(None),
         &PredefinedMenuItem::about(
             None,
             Some(AboutMetadata {

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -119,7 +119,7 @@ fn main() {
         &PredefinedMenuItem::maximize(None),
         &PredefinedMenuItem::close_window(Some("Close")),
         &PredefinedMenuItem::fullscreen(None),
-        &PredefinedMenuItem::front(None),
+        &PredefinedMenuItem::bring_all_to_front(None),
         &PredefinedMenuItem::about(
             None,
             Some(AboutMetadata {

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -109,6 +109,7 @@ fn main() {
         &PredefinedMenuItem::maximize(None),
         &PredefinedMenuItem::close_window(Some("Close")),
         &PredefinedMenuItem::fullscreen(None),
+        &PredefinedMenuItem::front(None),
         &PredefinedMenuItem::about(
             None,
             Some(AboutMetadata {

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -109,7 +109,7 @@ fn main() {
         &PredefinedMenuItem::maximize(None),
         &PredefinedMenuItem::close_window(Some("Close")),
         &PredefinedMenuItem::fullscreen(None),
-        &PredefinedMenuItem::front(None),
+        &PredefinedMenuItem::bring_all_to_front(None),
         &PredefinedMenuItem::about(
             None,
             Some(AboutMetadata {

--- a/examples/wry.rs
+++ b/examples/wry.rs
@@ -123,6 +123,7 @@ fn main() -> wry::Result<()> {
             &PredefinedMenuItem::maximize(None),
             &PredefinedMenuItem::close_window(Some("Close")),
             &PredefinedMenuItem::fullscreen(None),
+            &PredefinedMenuItem::front(None),
             &PredefinedMenuItem::about(
                 None,
                 Some(AboutMetadata {

--- a/examples/wry.rs
+++ b/examples/wry.rs
@@ -123,7 +123,7 @@ fn main() -> wry::Result<()> {
             &PredefinedMenuItem::maximize(None),
             &PredefinedMenuItem::close_window(Some("Close")),
             &PredefinedMenuItem::fullscreen(None),
-            &PredefinedMenuItem::front(None),
+            &PredefinedMenuItem::bring_all_to_front(None),
             &PredefinedMenuItem::about(
                 None,
                 Some(AboutMetadata {

--- a/src/items/predefined.rs
+++ b/src/items/predefined.rs
@@ -162,6 +162,15 @@ impl PredefinedMenuItem {
         PredefinedMenuItem::new(PredefinedMenuItemType::Services, text)
     }
 
+    /// 'Bring all windows in front' menu item
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Windows / Linux:** Unsupported.
+    pub fn front(text: Option<&str>) -> PredefinedMenuItem {
+        PredefinedMenuItem::new(PredefinedMenuItemType::Front, text)
+    }
+
     fn new<S: AsRef<str>>(item: PredefinedMenuItemType, text: Option<S>) -> Self {
         let item = crate::platform_impl::MenuChild::new_predefined(
             item,
@@ -250,6 +259,7 @@ pub(crate) enum PredefinedMenuItemType {
     Quit,
     About(Option<AboutMetadata>),
     Services,
+    Front,
     None,
 }
 
@@ -288,6 +298,7 @@ impl PredefinedMenuItemType {
             PredefinedMenuItemType::Quit => "&Quit",
             PredefinedMenuItemType::About(_) => "&About",
             PredefinedMenuItemType::Services => "Services",
+            PredefinedMenuItemType::Front => "Bring All to Front",
             PredefinedMenuItemType::None => "",
         }
     }

--- a/src/items/predefined.rs
+++ b/src/items/predefined.rs
@@ -162,13 +162,13 @@ impl PredefinedMenuItem {
         PredefinedMenuItem::new(PredefinedMenuItemType::Services, text)
     }
 
-    /// 'Bring all windows in front' menu item
+    /// 'Bring all to front' menu item
     ///
     /// ## Platform-specific:
     ///
     /// - **Windows / Linux:** Unsupported.
-    pub fn front(text: Option<&str>) -> PredefinedMenuItem {
-        PredefinedMenuItem::new(PredefinedMenuItemType::Front, text)
+    pub fn bring_all_to_front(text: Option<&str>) -> PredefinedMenuItem {
+        PredefinedMenuItem::new(PredefinedMenuItemType::BringAllToFront, text)
     }
 
     fn new<S: AsRef<str>>(item: PredefinedMenuItemType, text: Option<S>) -> Self {
@@ -259,7 +259,7 @@ pub(crate) enum PredefinedMenuItemType {
     Quit,
     About(Option<AboutMetadata>),
     Services,
-    Front,
+    BringAllToFront,
     None,
 }
 
@@ -298,7 +298,7 @@ impl PredefinedMenuItemType {
             PredefinedMenuItemType::Quit => "&Quit",
             PredefinedMenuItemType::About(_) => "&About",
             PredefinedMenuItemType::Services => "Services",
-            PredefinedMenuItemType::Front => "Bring All to Front",
+            PredefinedMenuItemType::BringAllToFront => "Bring All to Front",
             PredefinedMenuItemType::None => "",
         }
     }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -873,6 +873,7 @@ impl PredefinedMenuItemType {
             // manual implementation in `fire_menu_item_click`
             PredefinedMenuItemType::About(_) => Some(selector("fireMenuItemAction:")),
             PredefinedMenuItemType::Services => None,
+            PredefinedMenuItemType::Front => Some(selector("arrangeInFront:")),
             PredefinedMenuItemType::None => None,
         }
     }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -873,7 +873,7 @@ impl PredefinedMenuItemType {
             // manual implementation in `fire_menu_item_click`
             PredefinedMenuItemType::About(_) => Some(selector("fireMenuItemAction:")),
             PredefinedMenuItemType::Services => None,
-            PredefinedMenuItemType::Front => Some(selector("arrangeInFront:")),
+            PredefinedMenuItemType::BringAllToFront => Some(selector("arrangeInFront:")),
             PredefinedMenuItemType::None => None,
         }
     }


### PR DESCRIPTION
This PR adds 'Bring All to Front' predefined menu item on macOS.

<img width="408" alt="image" src="https://github.com/tauri-apps/muda/assets/823277/824176d9-3ac1-45bf-bc12-31ae31b4581e">

This is equivalent to `front` role in [Electron's `MenuItem` API](https://www.electronjs.org/docs/latest/api/menu-item#roles).
