### PR TITLE
ci: add running test with miri to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - run: cargo +nightly miri test

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -19,6 +19,7 @@ mod test {
     use crate::{CheckMenuItem, IconMenuItem, MenuId, MenuItem, PredefinedMenuItem, Submenu};
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore)]
     fn it_returns_same_id() {
         let id = MenuId::new("1");
         assert_eq!(id, MenuItem::with_id(id.clone(), "", true, None).id());
@@ -34,6 +35,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(miri, not(target_os = "linux")), ignore)]
     fn test_convert_from_id_and_into_id() {
         let id = "TEST ID";
         let expected = MenuId(id.to_string());


### PR DESCRIPTION
For T1 Rust targets Miri is able to check for several forms of undefined behavior that rustc can not.