### PR TITLE
fix(macos): fix panic when releasing separator menu item

### DIFF
--- a/.changes/fix-macos-separator-double-free.md
+++ b/.changes/fix-macos-separator-double-free.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On macOS, fixed a panic when releasing separator menu item.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -53,7 +53,6 @@ struct NsMenuRef(u32, id);
 impl Drop for NsMenuRef {
     fn drop(&mut self) {
         unsafe {
-            let _: () = msg_send![self.1, removeAllItems];
             let _: () = msg_send![self.1, release];
         }
     }


### PR DESCRIPTION
Seems the separator is already released by dropping the `NSMenuItemRef`.

I'm not sure if we really need `removeAllItem` here since `NSMenuItemRef` released the object

Related issues:
https://github.com/tauri-apps/tauri/issues/8465
https://github.com/tauri-apps/tauri/issues/8472