### PR TITLE
fix(macos): retain separator to prevent autorelease too early, closes #128

### DIFF
--- a/.changes/fix-mac-separator-autoreleased.md
+++ b/.changes/fix-mac-separator-autoreleased.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On macOS, fix a crash when appending separators.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -741,7 +741,11 @@ impl MenuChild {
     pub fn create_ns_item_for_predefined_menu_item(&mut self, menu_id: u32) -> crate::Result<id> {
         let item_type = self.predefined_item_type.as_ref().unwrap();
         let ns_menu_item = match item_type {
-            PredefinedMenuItemType::Separator => unsafe { NSMenuItem::separatorItem(nil) },
+            PredefinedMenuItemType::Separator => unsafe {
+                let separator = NSMenuItem::separatorItem(nil);
+                let _: () = msg_send![separator, retain];
+                separator
+            },
             _ => create_ns_menu_item(&self.text, item_type.selector(), &self.accelerator)?,
         };
 


### PR DESCRIPTION
Issue: https://github.com/tauri-apps/muda/issues/128

