### PR TITLE
fix(windows): do not remove menubar from menu when a context menu is dropped

### DIFF
--- a/.changes/windows-menubar-contextmenu.md
+++ b/.changes/windows-menubar-contextmenu.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+On Windows, fix menubar removed from window when another menu that was used as a conetxt menu is dropped.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -142,7 +142,6 @@ impl Drop for Menu {
                 RemoveWindowSubclass(*hwnd, Some(menu_subclass_proc), MENU_SUBCLASS_ID);
             }
             for hwnd in &self.context_hwnds {
-                SetMenu(*hwnd, 0);
                 RemoveWindowSubclass(*hwnd, Some(menu_subclass_proc), MENU_SUBCLASS_ID);
             }
             DestroyMenu(self.hmenu);


### PR DESCRIPTION
closes #163