### PR TITLE
fix(windows): always override context menu subclass

### DIFF
--- a/.changes/fix-multiple-context-menu.md
+++ b/.changes/fix-multiple-context-menu.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+On Windows, fix using multiple context menus resulted in receiving events only for the last used one.


### PR DESCRIPTION
Overriding the subclass using the same ID and function pointer, results in only updating the reference data
https://learn.microsoft.com/en-us/windows/win32/api/commctrl/nf-commctrl-setwindowsubclass#remarks

closes #162