### PR TITLE
fix(macos): crash on removing menu item

### DIFF
--- a/.changes/fix-macos-crash-on-remove.md
+++ b/.changes/fix-macos-crash-on-remove.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On macOS, fix a crash when removing a menu item.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -539,8 +539,7 @@ impl MenuChild {
                 AddOp::Append => {
                     for menus in self.ns_menus.as_ref().unwrap().values() {
                         for ns_menu in menus {
-                            let ns_menu_item: id =
-                                item.make_ns_item_for_menu(self.ns_menu.as_ref().unwrap().0)?;
+                            let ns_menu_item: id = item.make_ns_item_for_menu(ns_menu.0)?;
                             ns_menu.1.addItem_(ns_menu_item);
                         }
                     }
@@ -554,8 +553,7 @@ impl MenuChild {
                 AddOp::Insert(position) => {
                     for menus in self.ns_menus.as_ref().unwrap().values() {
                         for ns_menu in menus {
-                            let ns_menu_item: id =
-                                item.make_ns_item_for_menu(self.ns_menu.as_ref().unwrap().0)?;
+                            let ns_menu_item: id = item.make_ns_item_for_menu(ns_menu.0)?;
                             let () = msg_send![ns_menu.1, insertItem: ns_menu_item atIndex: position as NSInteger];
                         }
                     }


### PR DESCRIPTION
Before this patch, all `NSMenuItem` registered to the outer Submenu id, but it's actually added into the inner Submenu's `NSMenu`. When removing the menu item, lines here will call the outer Submenu's `NSMenu` to remove the menu item that is added in the inner Submenu's `NSMenu` hence exception is thrown: https://github.com/tauri-apps/muda/blob/6454ea269b1b9af09487d1ad4172b842fe841af5/src/platform_impl/macos/mod.rs#L634-L645

- test code
https://gist.github.com/pewsheen/12b6d63166cd9d0218c0b6c59d260502
