### PR TITLE
fix: set time for GTK context menu

### DIFF
--- a/.changes/gtk-context-menu.md
+++ b/.changes/gtk-context-menu.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On Linux, fix context menu closing immediately when right click is released.


### PR DESCRIPTION
This fixes tauri-apps/tauri#9658.
I noticed somehow that setting the `time` field of the GDK event prevents GTK from closing the menu on right click release.