### PR TITLE
fix(macos): close menu when dropping NsMenuRef, close #129, #173

### DIFF
--- a/.changes/mac-close-menu-before-release.md
+++ b/.changes/mac-close-menu-before-release.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On macOS, close tray menu before removing it to prevent user click on a released menu item.

--- a/.changes/mac-close-menu-before-release.md
+++ b/.changes/mac-close-menu-before-release.md
@@ -2,4 +2,4 @@
 "muda": patch
 ---
 
-On macOS, close tray menu before removing it to prevent user click on a released menu item.
+On macOS, close tray menu before removing it to prevent user click on a released menu item resulting in a crash.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -54,6 +54,7 @@ struct NsMenuRef(u32, id);
 impl Drop for NsMenuRef {
     fn drop(&mut self) {
         unsafe {
+            let _: () = msg_send![self.1, cancelTrackingWithoutAnimation];
             let _: () = msg_send![self.1, release];
         }
     }


### PR DESCRIPTION
Ref: https://github.com/tauri-apps/muda/issues/129, https://github.com/tauri-apps/muda/issues/173