### PR TITLE
fix: fix separator of `CARGO_PKG_AUTHORS` value in `from_cargo_metadata` macro

### DIFF
--- a/.changes/fix_cargo_pkg_authors_value_sep.md
+++ b/.changes/fix_cargo_pkg_authors_value_sep.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+Fix handling the separator of `CARGO_PKG_AUTHORS` environment variable value in `from_cargo_metadata` macro.

--- a/src/about_metadata.rs
+++ b/src/about_metadata.rs
@@ -104,7 +104,7 @@ macro_rules! from_cargo_metadata {
         #[cfg(not(target_os = "macos"))]
         {
             let authors = env!("CARGO_PKG_AUTHORS")
-                .split(';')
+                .split(':')
                 .map(|a| a.trim().to_string())
                 .collect::<::std::vec::Vec<_>>();
 


### PR DESCRIPTION
The separator of `CARGO_PKG_AUTHORS` environment variable value is `:`, but `from_cargo_metadata` macro tries to split the value with `;` separator. This PR fixes it.

https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates

> CARGO_PKG_AUTHORS — Colon separated list of authors from the manifest of your package.