### PR TITLE
fix(windows): use `TPM_RETURNCMD` instead of subclass for context menus

### DIFF
--- a/.changes/win32-context-menu-fixes
+++ b/.changes/win32-context-menu-fixes
@@ -2,12 +2,4 @@
 "muda": "patch"
 ---
 
-These changes are to address a design flaw in how `muda` handles context menus on Windows.
-    
-The normal way menus with `muda` are used on Windows is they get attached to a window, and the window is subclassed to intercept commands (`WM_COMMAND`) and some drawing behaviors (I'm not 100% sure on this, but this appears in place to support theming and dark mode).  When the `Menu` is dropped, it will be unattached from all windows and the subclasses will be removed.
-    
-Context menus seem to follow a slightly different pattern.  When `show_context_menu_for_hwnd()` is called, the subclass is attached to the window, but never removed.  This behavior is problematic because the menu can be dropped without the subclass removed, causing a crash.  Furthermore, having this subclass attached unnecessarily is not necessarily a good idea.
-    
-These changes to `muda` refactor menu support on Windows to remove the HWND subclassing when the context menu is active.
-    
-These changes also address a memory leak where when an HWND is subclassed, the reference to the menu object was placed in a `Box` seemingly unnecessarily, and this `Box` never seems to be dropped.  This was changed to using straight references.
+On Windows, fix crash when showing a context menu but dropping the Menu before the context menu is closed.

--- a/.changes/win32-context-menu-fixes
+++ b/.changes/win32-context-menu-fixes
@@ -1,0 +1,13 @@
+---
+"muda": "patch"
+---
+
+These changes are to address a design flaw in how `muda` handles context menus on Windows.
+    
+The normal way menus with `muda` are used on Windows is they get attached to a window, and the window is subclassed to intercept commands (`WM_COMMAND`) and some drawing behaviors (I'm not 100% sure on this, but this appears in place to support theming and dark mode).  When the `Menu` is dropped, it will be unattached from all windows and the subclasses will be removed.
+    
+Context menus seem to follow a slightly different pattern.  When `show_context_menu_for_hwnd()` is called, the subclass is attached to the window, but never removed.  This behavior is problematic because the menu can be dropped without the subclass removed, causing a crash.  Furthermore, having this subclass attached unnecessarily is not necessarily a good idea.
+    
+These changes to `muda` refactor menu support on Windows to remove the HWND subclassing when the context menu is active.
+    
+These changes also address a memory leak where when an HWND is subclassed, the reference to the menu object was placed in a `Box` seemingly unnecessarily, and this `Box` never seems to be dropped.  This was changed to using straight references.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -413,22 +413,7 @@ impl Menu {
     }
 
     pub fn show_context_menu_for_hwnd(&mut self, hwnd: isize, position: Option<Position>) {
-        unsafe {
-            SetWindowSubclass(
-                hwnd as _,
-                Some(menu_subclass_proc),
-                CONTEXT_MENU_SUBCLASS_ID,
-                dwrefdata_from_obj(self),
-            );
-        }
         let rc = show_context_menu(hwnd as _, self.hpopupmenu, position);
-        unsafe {
-            RemoveWindowSubclass(
-                hwnd as _,
-                Some(menu_subclass_proc),
-                CONTEXT_MENU_SUBCLASS_ID,
-            );
-        }
         if let Some(item) = rc.and_then(|rc| self.find_by_id(rc)) {
             unsafe {
                 menu_selected(hwnd as _, &mut item.borrow_mut());
@@ -935,22 +920,7 @@ impl MenuChild {
     }
 
     pub fn show_context_menu_for_hwnd(&mut self, hwnd: isize, position: Option<Position>) {
-        unsafe {
-            SetWindowSubclass(
-                hwnd as _,
-                Some(menu_subclass_proc),
-                CONTEXT_SUBMENU_SUBCLASS_ID,
-                dwrefdata_from_obj(self),
-            );
-        }
         let rc = show_context_menu(hwnd as _, self.hpopupmenu, position);
-        unsafe {
-            RemoveWindowSubclass(
-                hwnd as _,
-                Some(menu_subclass_proc),
-                CONTEXT_SUBMENU_SUBCLASS_ID,
-            );
-        }
         if let Some(item) = rc.and_then(|rc| self.find_by_id(rc)) {
             unsafe {
                 menu_selected(hwnd as _, &mut item.borrow_mut());
@@ -1083,8 +1053,6 @@ unsafe fn obj_from_dwrefdata<T>(dwrefdata: usize) -> &'static mut T {
 const MENU_SUBCLASS_ID: usize = 200;
 const MENU_UPDATE_THEME: u32 = 201;
 const SUBMENU_SUBCLASS_ID: usize = 202;
-const CONTEXT_MENU_SUBCLASS_ID: usize = 203;
-const CONTEXT_SUBMENU_SUBCLASS_ID: usize = 204;
 
 unsafe extern "system" fn menu_subclass_proc(
     hwnd: windows_sys::Win32::Foundation::HWND,
@@ -1106,11 +1074,11 @@ unsafe extern "system" fn menu_subclass_proc(
             let id = util::LOWORD(wparam as _) as u32;
 
             let item = match uidsubclass {
-                MENU_SUBCLASS_ID | CONTEXT_MENU_SUBCLASS_ID => {
+                MENU_SUBCLASS_ID => {
                     let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
                     menu.find_by_id(id)
                 }
-                SUBMENU_SUBCLASS_ID | CONTEXT_SUBMENU_SUBCLASS_ID => {
+                SUBMENU_SUBCLASS_ID => {
                     let menu = obj_from_dwrefdata::<MenuChild>(dwrefdata);
                     menu.find_by_id(id)
                 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1127,7 +1127,7 @@ unsafe extern "system" fn menu_subclass_proc(
 
         WM_UAHDRAWMENUITEM | WM_UAHDRAWMENU if uidsubclass == MENU_SUBCLASS_ID => {
             let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
-            let theme = (*menu)
+            let theme = menu
                 .hwnds
                 .get(&(hwnd as _))
                 .copied()
@@ -1145,7 +1145,7 @@ unsafe extern "system" fn menu_subclass_proc(
             let res = DefSubclassProc(hwnd as _, msg, wparam, lparam);
 
             let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
-            let theme = (*menu)
+            let theme = menu
                 .hwnds
                 .get(&(hwnd as _))
                 .copied()

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -39,7 +39,7 @@ use windows_sys::Win32::{
             HMENU, MENUITEMINFOW, MFS_CHECKED, MFS_DISABLED, MF_BYCOMMAND, MF_BYPOSITION,
             MF_CHECKED, MF_DISABLED, MF_ENABLED, MF_GRAYED, MF_POPUP, MF_SEPARATOR, MF_STRING,
             MF_UNCHECKED, MIIM_BITMAP, MIIM_STATE, MIIM_STRING, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE,
-            TPM_LEFTALIGN, WM_CLOSE, WM_COMMAND, WM_NCACTIVATE, WM_NCPAINT,
+            TPM_LEFTALIGN, TPM_RETURNCMD, WM_CLOSE, WM_COMMAND, WM_NCACTIVATE, WM_NCPAINT,
         },
     },
 };
@@ -338,7 +338,7 @@ impl Menu {
                 hwnd as _,
                 Some(menu_subclass_proc),
                 MENU_SUBCLASS_ID,
-                Box::into_raw(Box::new(self)) as _,
+                dwrefdata_from_obj(self),
             );
             DrawMenuBar(hwnd as _);
         };
@@ -368,7 +368,7 @@ impl Menu {
                 hwnd as _,
                 Some(menu_subclass_proc),
                 MENU_SUBCLASS_ID,
-                Box::into_raw(Box::new(self)) as _,
+                dwrefdata_from_obj(self),
             );
         }
     }
@@ -413,16 +413,27 @@ impl Menu {
     }
 
     pub fn show_context_menu_for_hwnd(&mut self, hwnd: isize, position: Option<Position>) {
-        let hpopupmenu = self.hpopupmenu;
         unsafe {
             SetWindowSubclass(
                 hwnd as _,
                 Some(menu_subclass_proc),
                 CONTEXT_MENU_SUBCLASS_ID,
-                Box::into_raw(Box::new(self)) as _,
+                dwrefdata_from_obj(self),
             );
         }
-        show_context_menu(hwnd as _, hpopupmenu, position)
+        let rc = show_context_menu(hwnd as _, self.hpopupmenu, position);
+        unsafe {
+            RemoveWindowSubclass(
+                hwnd as _,
+                Some(menu_subclass_proc),
+                CONTEXT_MENU_SUBCLASS_ID,
+            );
+        }
+        if let Some(item) = rc.and_then(|rc| self.find_by_id(rc)) {
+            unsafe {
+                menu_selected(hwnd as _, &mut item.borrow_mut());
+            }
+        }
     }
 
     pub fn set_theme_for_hwnd(&self, hwnd: isize, theme: MenuTheme) -> crate::Result<()> {
@@ -924,16 +935,27 @@ impl MenuChild {
     }
 
     pub fn show_context_menu_for_hwnd(&mut self, hwnd: isize, position: Option<Position>) {
-        let hpopupmenu = self.hpopupmenu;
         unsafe {
             SetWindowSubclass(
                 hwnd as _,
                 Some(menu_subclass_proc),
                 CONTEXT_SUBMENU_SUBCLASS_ID,
-                Box::into_raw(Box::new(self)) as _,
+                dwrefdata_from_obj(self),
             );
         }
-        show_context_menu(hwnd as _, hpopupmenu, position)
+        let rc = show_context_menu(hwnd as _, self.hpopupmenu, position);
+        unsafe {
+            RemoveWindowSubclass(
+                hwnd as _,
+                Some(menu_subclass_proc),
+                CONTEXT_SUBMENU_SUBCLASS_ID,
+            );
+        }
+        if let Some(item) = rc.and_then(|rc| self.find_by_id(rc)) {
+            unsafe {
+                menu_selected(hwnd as _, &mut item.borrow_mut());
+            }
+        }
     }
 
     pub fn attach_menu_subclass_for_hwnd(&self, hwnd: isize) {
@@ -942,7 +964,7 @@ impl MenuChild {
                 hwnd as _,
                 Some(menu_subclass_proc),
                 SUBMENU_SUBCLASS_ID,
-                Box::into_raw(Box::new(self)) as _,
+                dwrefdata_from_obj(self),
             );
         }
     }
@@ -982,8 +1004,8 @@ fn show_context_menu(
     hwnd: windows_sys::Win32::Foundation::HWND,
     hmenu: HMENU,
     position: Option<Position>,
-) {
-    unsafe {
+) -> Option<u32> {
+    let result = unsafe {
         let pt = if let Some(pos) = position {
             let dpi = util::hwnd_dpi(hwnd);
             let scale_factor = util::dpi_to_scale_factor(dpi);
@@ -1000,8 +1022,17 @@ fn show_context_menu(
             pt
         };
         SetForegroundWindow(hwnd);
-        TrackPopupMenu(hmenu, TPM_LEFTALIGN, pt.x, pt.y, 0, hwnd, std::ptr::null());
-    }
+        TrackPopupMenu(
+            hmenu,
+            TPM_LEFTALIGN | TPM_RETURNCMD,
+            pt.x,
+            pt.y,
+            0,
+            hwnd,
+            std::ptr::null(),
+        )
+    };
+    (result > 0).then_some(result.try_into().ok()).flatten()
 }
 
 struct AccelAction;
@@ -1041,6 +1072,14 @@ fn create_icon_item_info(hbitmap: HBITMAP) -> MENUITEMINFOW {
     info
 }
 
+fn dwrefdata_from_obj<T>(obj: &T) -> usize {
+    (obj as *const T) as usize
+}
+
+unsafe fn obj_from_dwrefdata<T>(dwrefdata: usize) -> &'static mut T {
+    unsafe { (dwrefdata as *mut T).as_mut().unwrap() }
+}
+
 const MENU_SUBCLASS_ID: usize = 200;
 const MENU_UPDATE_THEME: u32 = 201;
 const SUBMENU_SUBCLASS_ID: usize = 202;
@@ -1057,9 +1096,9 @@ unsafe extern "system" fn menu_subclass_proc(
 ) -> LRESULT {
     match msg {
         MENU_UPDATE_THEME if uidsubclass == MENU_SUBCLASS_ID => {
-            let menu = dwrefdata as *mut Box<Menu>;
+            let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
             let theme: MenuTheme = std::mem::transmute(wparam);
-            (*menu).hwnds.insert(hwnd as _, theme);
+            menu.hwnds.insert(hwnd as _, theme);
             0
         }
 
@@ -1068,82 +1107,18 @@ unsafe extern "system" fn menu_subclass_proc(
 
             let item = match uidsubclass {
                 MENU_SUBCLASS_ID | CONTEXT_MENU_SUBCLASS_ID => {
-                    let menu = dwrefdata as *mut Box<Menu>;
-                    (*menu).find_by_id(id)
+                    let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
+                    menu.find_by_id(id)
                 }
                 SUBMENU_SUBCLASS_ID | CONTEXT_SUBMENU_SUBCLASS_ID => {
-                    let menu = dwrefdata as *mut Box<MenuChild>;
-                    (*menu).find_by_id(id)
+                    let menu = obj_from_dwrefdata::<MenuChild>(dwrefdata);
+                    menu.find_by_id(id)
                 }
                 _ => unreachable!(),
             };
 
             if let Some(item) = item {
-                let (mut dispatch, mut menu_id) = (true, None);
-
-                {
-                    let mut item = item.borrow_mut();
-
-                    if item.item_type() == MenuItemType::Predefined {
-                        dispatch = false;
-                    } else {
-                        menu_id.replace(item.id.clone());
-                    }
-
-                    match item.item_type() {
-                        MenuItemType::Check => {
-                            let checked = !item.checked;
-                            item.set_checked(checked);
-                        }
-                        MenuItemType::Predefined => {
-                            if let Some(predefined_item_type) = &item.predefined_item_type {
-                                match predefined_item_type {
-                                    PredefinedMenuItemType::Copy => {
-                                        execute_edit_command(EditCommand::Copy)
-                                    }
-                                    PredefinedMenuItemType::Cut => {
-                                        execute_edit_command(EditCommand::Cut)
-                                    }
-                                    PredefinedMenuItemType::Paste => {
-                                        execute_edit_command(EditCommand::Paste)
-                                    }
-                                    PredefinedMenuItemType::SelectAll => {
-                                        execute_edit_command(EditCommand::SelectAll)
-                                    }
-                                    PredefinedMenuItemType::Separator => {}
-                                    PredefinedMenuItemType::Minimize => {
-                                        ShowWindow(hwnd, SW_MINIMIZE);
-                                    }
-                                    PredefinedMenuItemType::Maximize => {
-                                        ShowWindow(hwnd, SW_MAXIMIZE);
-                                    }
-                                    PredefinedMenuItemType::Hide => {
-                                        ShowWindow(hwnd, SW_HIDE);
-                                    }
-                                    PredefinedMenuItemType::CloseWindow => {
-                                        SendMessageW(hwnd, WM_CLOSE, 0, 0);
-                                    }
-                                    PredefinedMenuItemType::Quit => {
-                                        PostQuitMessage(0);
-                                    }
-                                    PredefinedMenuItemType::About(Some(ref metadata)) => {
-                                        show_about_dialog(hwnd as _, metadata)
-                                    }
-
-                                    _ => {}
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-
-                if dispatch {
-                    MenuEvent::send(MenuEvent {
-                        id: menu_id.unwrap(),
-                    });
-                }
-
+                menu_selected(hwnd, &mut item.borrow_mut());
                 0
             } else {
                 DefSubclassProc(hwnd as _, msg, wparam, lparam)
@@ -1151,7 +1126,7 @@ unsafe extern "system" fn menu_subclass_proc(
         }
 
         WM_UAHDRAWMENUITEM | WM_UAHDRAWMENU if uidsubclass == MENU_SUBCLASS_ID => {
-            let menu = dwrefdata as *mut Box<Menu>;
+            let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
             let theme = (*menu)
                 .hwnds
                 .get(&(hwnd as _))
@@ -1169,7 +1144,7 @@ unsafe extern "system" fn menu_subclass_proc(
             // custom dark menu redraw
             let res = DefSubclassProc(hwnd as _, msg, wparam, lparam);
 
-            let menu = dwrefdata as *mut Box<Menu>;
+            let menu = obj_from_dwrefdata::<Menu>(dwrefdata);
             let theme = (*menu)
                 .hwnds
                 .get(&(hwnd as _))
@@ -1183,6 +1158,65 @@ unsafe extern "system" fn menu_subclass_proc(
         }
 
         _ => DefSubclassProc(hwnd as _, msg, wparam, lparam),
+    }
+}
+
+unsafe fn menu_selected(hwnd: windows_sys::Win32::Foundation::HWND, item: &mut MenuChild) {
+    let (mut dispatch, mut menu_id) = (true, None);
+
+    {
+        if item.item_type() == MenuItemType::Predefined {
+            dispatch = false;
+        } else {
+            menu_id.replace(item.id.clone());
+        }
+
+        match item.item_type() {
+            MenuItemType::Check => {
+                let checked = !item.checked;
+                item.set_checked(checked);
+            }
+            MenuItemType::Predefined => {
+                if let Some(predefined_item_type) = &item.predefined_item_type {
+                    match predefined_item_type {
+                        PredefinedMenuItemType::Copy => execute_edit_command(EditCommand::Copy),
+                        PredefinedMenuItemType::Cut => execute_edit_command(EditCommand::Cut),
+                        PredefinedMenuItemType::Paste => execute_edit_command(EditCommand::Paste),
+                        PredefinedMenuItemType::SelectAll => {
+                            execute_edit_command(EditCommand::SelectAll)
+                        }
+                        PredefinedMenuItemType::Separator => {}
+                        PredefinedMenuItemType::Minimize => {
+                            ShowWindow(hwnd, SW_MINIMIZE);
+                        }
+                        PredefinedMenuItemType::Maximize => {
+                            ShowWindow(hwnd, SW_MAXIMIZE);
+                        }
+                        PredefinedMenuItemType::Hide => {
+                            ShowWindow(hwnd, SW_HIDE);
+                        }
+                        PredefinedMenuItemType::CloseWindow => {
+                            SendMessageW(hwnd, WM_CLOSE, 0, 0);
+                        }
+                        PredefinedMenuItemType::Quit => {
+                            PostQuitMessage(0);
+                        }
+                        PredefinedMenuItemType::About(Some(ref metadata)) => {
+                            show_about_dialog(hwnd as _, metadata)
+                        }
+
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if dispatch {
+        MenuEvent::send(MenuEvent {
+            id: menu_id.unwrap(),
+        });
     }
 }
 


### PR DESCRIPTION
These changes are to address a design flaw in how `muda` handles context menus on Windows.

The normal way menus with `muda` are used on Windows is they get attached to a window, and the window is subclassed to intercept commands (`WM_COMMAND`) and some drawing behaviors (I'm not 100% sure on this, but this appears in place to support theming and dark mode).  When the `Menu` is dropped, it will be unattached from all windows and the subclasses will be removed.

Context menus seem to follow a slightly different pattern.  When `show_context_menu_for_hwnd()` is called, the subclass is attached to the window, but never removed.  This behavior is problematic because the menu can be dropped without the subclass removed, causing a crash.  Furthermore, having this subclass attached unnecessarily is not necessarily a good idea.

These changes to `muda` refactor menu support on Windows to ensure that the subclass (which seems to be necessary to support theming) lives only while the context menu is active, which should address these problems.

These changes also address a memory leak where when an HWND is subclassed, the reference to the menu object was placed in a `Box` seemingly unnecessarily, and this `Box` never seems to be dropped.  This was changed to using straight references.