### PR TITLE
Don't expose macOS implementation details in the public API

### DIFF
--- a/.changes/make-macos-impl-details-private.md
+++ b/.changes/make-macos-impl-details-private.md
@@ -1,0 +1,5 @@
+---
+"muda": minor
+---
+
+**Breaking Change** Changed the type of the pointer passed in `show_context_menu_for_nsview` to `c_void`, and make the method `unsafe`.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ menu.show_context_menu_for_hwnd(window.hwnd() as isize, Some(position.into()));
 #[cfg(target_os = "linux")]
 menu.show_context_menu_for_gtk_window(&gtk_window, Some(position.into()));
 #[cfg(target_os = "macos")]
-menu.show_context_menu_for_nsview(nsview, Some(position.into()));
+unsafe { menu.show_context_menu_for_nsview(nsview, Some(position.into())) };
 ```
 
 ## Processing menu events

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -225,7 +225,9 @@ fn show_context_menu(window: &Window, menu: &dyn ContextMenu, position: Option<P
     #[cfg(target_os = "linux")]
     menu.show_context_menu_for_gtk_window(window.gtk_window().as_ref(), position);
     #[cfg(target_os = "macos")]
-    menu.show_context_menu_for_nsview(window.ns_view() as _, position);
+    unsafe {
+        menu.show_context_menu_for_nsview(window.ns_view() as _, position);
+    }
 }
 
 fn load_icon(path: &std::path::Path) -> muda::Icon {

--- a/examples/windows-common-controls-v6/src/main.rs
+++ b/examples/windows-common-controls-v6/src/main.rs
@@ -213,7 +213,7 @@ fn show_context_menu(window: &Window, menu: &dyn ContextMenu, position: Option<P
     {
         use tao::rwh_06::*;
         if let RawWindowHandle::AppKit(handle) = window.window_handle().unwrap().as_raw() {
-            menu.show_context_menu_for_nsview(handle.ns_view.as_ptr() as _, position);
+            unsafe { menu.show_context_menu_for_nsview(handle.ns_view.as_ptr() as _, position) };
         }
     }
 }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -213,7 +213,7 @@ fn show_context_menu(window: &Window, menu: &dyn ContextMenu, position: Option<P
     {
         use winit::raw_window_handle::*;
         if let RawWindowHandle::AppKit(handle) = window.window_handle().unwrap().as_raw() {
-            menu.show_context_menu_for_nsview(handle.ns_view.as_ptr() as _, position);
+            unsafe { menu.show_context_menu_for_nsview(handle.ns_view.as_ptr() as _, position) };
         }
     }
 }

--- a/examples/wry.rs
+++ b/examples/wry.rs
@@ -310,7 +310,9 @@ fn show_context_menu(window: &Window, menu: &dyn ContextMenu, position: Option<P
     #[cfg(target_os = "linux")]
     menu.show_context_menu_for_gtk_window(window.gtk_window().as_ref(), position);
     #[cfg(target_os = "macos")]
-    menu.show_context_menu_for_nsview(window.ns_view() as _, position);
+    unsafe {
+        menu.show_context_menu_for_nsview(window.ns_view() as _, position);
+    }
 }
 
 fn load_icon(path: &std::path::Path) -> muda::Icon {

--- a/src/items/submenu.rs
+++ b/src/items/submenu.rs
@@ -246,10 +246,16 @@ impl ContextMenu for Submenu {
     }
 
     #[cfg(target_os = "macos")]
-    fn show_context_menu_for_nsview(&self, view: cocoa::base::id, position: Option<Position>) {
-        self.inner
-            .borrow_mut()
-            .show_context_menu_for_nsview(view, position)
+    unsafe fn show_context_menu_for_nsview(
+        &self,
+        view: *const std::ffi::c_void,
+        position: Option<Position>,
+    ) {
+        unsafe {
+            self.inner
+                .borrow_mut()
+                .show_context_menu_for_nsview(view, position)
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -370,10 +370,17 @@ impl ContextMenu for Menu {
     }
 
     #[cfg(target_os = "macos")]
-    fn show_context_menu_for_nsview(&self, view: cocoa::base::id, position: Option<Position>) {
-        self.inner
-            .borrow_mut()
-            .show_context_menu_for_nsview(view, position)
+    unsafe fn show_context_menu_for_nsview(
+        &self,
+        view: *const std::ffi::c_void,
+        position: Option<Position>,
+    ) {
+        // SAFETY: Upheld by caller
+        unsafe {
+            self.inner
+                .borrow_mut()
+                .show_context_menu_for_nsview(view, position)
+        }
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
The `show_context_menu_for_nsview` method previously used the `objc::runtime::Object` type, which means that the library's dependence on `objc` is exposed as part of the public API.

Additionally, since the method is taking a raw pointer (and as such is unsound because it allows passing e.g. `ptr::dangling()`), I took the opportunity to also mark the method as `unsafe`.

This is done in preparation for transitioning to `objc2`, CC https://github.com/tauri-apps/wry/issues/1239.