### PR TITLE
feat: return context menu dismiss result

### DIFF
--- a/.changes/add-context-menu-dismiss-result.md
+++ b/.changes/add-context-menu-dismiss-result.md
@@ -2,4 +2,4 @@
 "muda": patch
 ---
 
-On macOS and Windows, context menu returns it's dismissed result.
+Return `bool` in `ContextMenu::show_context_menu_for_hwnd` on Windows and `ContextMenu::show_context_menu_for_nsview` on macOS to indicate why the context menu was closed.

--- a/.changes/add-context-menu-dismiss-result.md
+++ b/.changes/add-context-menu-dismiss-result.md
@@ -1,5 +1,5 @@
 ---
-"muda": patch
+"muda": minor
 ---
 
-Return `bool` in `ContextMenu::show_context_menu_for_hwnd` on Windows and `ContextMenu::show_context_menu_for_nsview` on macOS to indicate why the context menu was closed.
+Return `bool` in `ContextMenu::show_context_menu_for_hwnd`, `ContextMenu::show_context_menu_for_nsview` and `ContextMenu::show_context_menu_for_gtk_window` to indicate why the context menu was closed.

--- a/.changes/add-context-menu-dismiss-result.md
+++ b/.changes/add-context-menu-dismiss-result.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On macOS and Windows, context menu returns it's dismissed result.

--- a/src/items/submenu.rs
+++ b/src/items/submenu.rs
@@ -250,7 +250,7 @@ impl ContextMenu for Submenu {
         &self,
         view: *const std::ffi::c_void,
         position: Option<Position>,
-    ) {
+    ) -> bool {
         self.inner
             .borrow_mut()
             .show_context_menu_for_nsview(view, position)

--- a/src/items/submenu.rs
+++ b/src/items/submenu.rs
@@ -217,7 +217,7 @@ impl ContextMenu for Submenu {
     }
 
     #[cfg(target_os = "windows")]
-    unsafe fn show_context_menu_for_hwnd(&self, hwnd: isize, position: Option<Position>) {
+    unsafe fn show_context_menu_for_hwnd(&self, hwnd: isize, position: Option<Position>) -> bool {
         self.inner
             .borrow_mut()
             .show_context_menu_for_hwnd(hwnd, position)

--- a/src/items/submenu.rs
+++ b/src/items/submenu.rs
@@ -234,7 +234,11 @@ impl ContextMenu for Submenu {
     }
 
     #[cfg(target_os = "linux")]
-    fn show_context_menu_for_gtk_window(&self, w: &gtk::Window, position: Option<Position>) {
+    fn show_context_menu_for_gtk_window(
+        &self,
+        w: &gtk::Window,
+        position: Option<Position>,
+    ) -> bool {
         self.inner
             .borrow_mut()
             .show_context_menu_for_gtk_window(w, position)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,11 +311,17 @@ pub trait ContextMenu {
     ///
     /// - `position` is relative to the window top-left corner, if `None`, the cursor position is used.
     ///
+    /// Returns `true` if menu tracking ended because an item was selected, and `false` if menu tracking was cancelled for any reason.
+    ///
     /// # Safety
     ///
     /// The `hwnd` must be a valid window HWND.
     #[cfg(target_os = "windows")]
-    unsafe fn show_context_menu_for_hwnd(&self, hwnd: isize, position: Option<dpi::Position>);
+    unsafe fn show_context_menu_for_hwnd(
+        &self,
+        hwnd: isize,
+        position: Option<dpi::Position>,
+    ) -> bool;
 
     /// Attach the menu subclass handler to the given hwnd
     /// so you can recieve events from that window using [MenuEvent::receiver]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,8 @@ pub trait ContextMenu {
     ///
     /// - `position` is relative to the window top-left corner, if `None`, the cursor position is used.
     ///
+    /// Returns `true` if menu tracking ended because an item was selected, and `false` if menu tracking was cancelled for any reason.
+    ///
     /// # Safety
     ///
     /// The view must be a pointer to a valid `NSView`.
@@ -362,7 +364,7 @@ pub trait ContextMenu {
         &self,
         view: *const std::ffi::c_void,
         position: Option<dpi::Position>,
-    );
+    ) -> bool;
 
     /// Get the underlying NSMenu reserved for context menus.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ pub trait ContextMenu {
     ///
     /// - `position` is relative to the window top-left corner, if `None`, the cursor position is used.
     ///
-    /// Returns `true` if menu tracking ended because an item was selected or clicked other place to dismiss the menu
+    /// Returns `true` if menu tracking ended because an item was selected or clicked outside the menu to dismiss it.
     ///
     /// Returns `false` if menu tracking was cancelled for any reason.
     #[cfg(target_os = "linux")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,8 +347,16 @@ pub trait ContextMenu {
     /// Shows this menu as a context menu inside a [`gtk::Window`]
     ///
     /// - `position` is relative to the window top-left corner, if `None`, the cursor position is used.
+    ///
+    /// Returns `true` if menu tracking ended because an item was selected or clicked other place to dismiss the menu
+    ///
+    /// Returns `false` if menu tracking was cancelled for any reason.
     #[cfg(target_os = "linux")]
-    fn show_context_menu_for_gtk_window(&self, w: &gtk::Window, position: Option<dpi::Position>);
+    fn show_context_menu_for_gtk_window(
+        &self,
+        w: &gtk::Window,
+        position: Option<dpi::Position>,
+    ) -> bool;
 
     /// Get the underlying gtk menu reserved for context menus.
     ///

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -408,7 +408,7 @@ impl ContextMenu for Menu {
         &self,
         view: *const std::ffi::c_void,
         position: Option<Position>,
-    ) {
+    ) -> bool {
         self.inner
             .borrow_mut()
             .show_context_menu_for_nsview(view, position)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -392,7 +392,11 @@ impl ContextMenu for Menu {
     }
 
     #[cfg(target_os = "linux")]
-    fn show_context_menu_for_gtk_window(&self, window: &gtk::Window, position: Option<Position>) {
+    fn show_context_menu_for_gtk_window(
+        &self,
+        window: &gtk::Window,
+        position: Option<Position>,
+    ) -> bool {
         self.inner
             .borrow_mut()
             .show_context_menu_for_gtk_window(window, position)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -375,7 +375,7 @@ impl ContextMenu for Menu {
     }
 
     #[cfg(target_os = "windows")]
-    unsafe fn show_context_menu_for_hwnd(&self, hwnd: isize, position: Option<Position>) {
+    unsafe fn show_context_menu_for_hwnd(&self, hwnd: isize, position: Option<Position>) -> bool {
         self.inner
             .borrow_mut()
             .show_context_menu_for_hwnd(hwnd, position)

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -368,7 +368,7 @@ impl Menu {
         &mut self,
         widget: &impl IsA<gtk::Widget>,
         position: Option<Position>,
-    ) {
+    ) -> bool {
         show_context_menu(self.gtk_context_menu(), widget, position)
     }
 
@@ -952,7 +952,7 @@ impl MenuChild {
         &mut self,
         widget: &impl IsA<gtk::Widget>,
         position: Option<Position>,
-    ) {
+    ) -> bool {
         show_context_menu(self.gtk_context_menu(), widget, position)
     }
 
@@ -1364,7 +1364,7 @@ fn show_context_menu(
     gtk_menu: gtk::Menu,
     widget: &impl IsA<gtk::Widget>,
     position: Option<Position>,
-) {
+) -> bool {
     let (pos, window) = if let Some(pos) = position {
         let window = widget.window();
         (
@@ -1411,6 +1411,12 @@ fn show_context_menu(
             }
         }
 
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let tx_clone = tx.clone();
+        gtk_menu.connect_cancel(move |_| tx_clone.send(false).unwrap_or(()));
+        let tx_clone = tx.clone();
+        gtk_menu.connect_selection_done(move |_| tx_clone.send(true).unwrap_or(()));
+
         gtk_menu.popup_at_rect(
             &window,
             &gdk::Rectangle::new(pos.0, pos.1, 0, 0),
@@ -1418,7 +1424,22 @@ fn show_context_menu(
             gdk::Gravity::NorthWest,
             Some(&event),
         );
+
+        loop {
+            gtk::main_iteration();
+
+            match rx.try_recv() {
+                Ok(result) => return result,
+                Err(err) => {
+                    if err.is_disconnected() {
+                        return false;
+                    }
+                }
+            }
+        }
     }
+
+    false
 }
 
 impl PredefinedMenuItemType {

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -1413,9 +1413,8 @@ fn show_context_menu(
 
         let (tx, rx) = crossbeam_channel::unbounded();
         let tx_clone = tx.clone();
-        gtk_menu.connect_cancel(move |_| tx_clone.send(false).unwrap_or(()));
-        let tx_clone = tx.clone();
-        gtk_menu.connect_selection_done(move |_| tx_clone.send(true).unwrap_or(()));
+        let id = gtk_menu.connect_cancel(move |_| tx_clone.send(false).unwrap_or(()));
+        let id2 = gtk_menu.connect_selection_done(move |s| tx.send(true).unwrap_or(()));
 
         gtk_menu.popup_at_rect(
             &window,
@@ -1429,9 +1428,15 @@ fn show_context_menu(
             gtk::main_iteration();
 
             match rx.try_recv() {
-                Ok(result) => return result,
+                Ok(result) => {
+                    gtk_menu.disconnect(id);
+                    gtk_menu.disconnect(id2);
+                    return result;
+                }
                 Err(err) => {
                     if err.is_disconnected() {
+                        gtk_menu.disconnect(id);
+                        gtk_menu.disconnect(id2);
                         return false;
                     }
                 }

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -1414,7 +1414,7 @@ fn show_context_menu(
         let (tx, rx) = crossbeam_channel::unbounded();
         let tx_clone = tx.clone();
         let id = gtk_menu.connect_cancel(move |_| tx_clone.send(false).unwrap_or(()));
-        let id2 = gtk_menu.connect_selection_done(move |s| tx.send(true).unwrap_or(()));
+        let id2 = gtk_menu.connect_selection_done(move |_| tx.send(true).unwrap_or(()));
 
         gtk_menu.popup_at_rect(
             &window,

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -175,7 +175,7 @@ impl Menu {
         &self,
         view: *const c_void,
         position: Option<Position>,
-    ) {
+    ) -> bool {
         // SAFETY: Upheld by caller
         show_context_menu(&self.ns_menu.1, view, position)
     }
@@ -660,7 +660,7 @@ impl MenuChild {
         &self,
         view: *const c_void,
         position: Option<Position>,
-    ) {
+    ) -> bool {
         show_context_menu(&self.ns_menu.as_ref().unwrap().1, view, position)
     }
 
@@ -1100,7 +1100,11 @@ fn menuitem_set_native_icon(menuitem: &NSMenuItem, icon: Option<NativeIcon>) {
     }
 }
 
-unsafe fn show_context_menu(ns_menu: &NSMenu, view: *const c_void, position: Option<Position>) {
+unsafe fn show_context_menu(
+    ns_menu: &NSMenu,
+    view: *const c_void,
+    position: Option<Position>,
+) -> bool {
     // SAFETY: Caller verifies that the view is valid.
     let view: &NSView = unsafe { &*view.cast() };
 
@@ -1120,7 +1124,7 @@ unsafe fn show_context_menu(ns_menu: &NSMenu, view: *const c_void, position: Opt
         (location, None)
     };
 
-    let _ = unsafe { ns_menu.popUpMenuPositioningItem_atLocation_inView(None, location, in_view) };
+    unsafe { ns_menu.popUpMenuPositioningItem_atLocation_inView(None, location, in_view) }
 }
 
 impl NativeIcon {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -415,11 +415,19 @@ impl Menu {
             .unwrap_or(false)
     }
 
-    pub unsafe fn show_context_menu_for_hwnd(&mut self, hwnd: isize, position: Option<Position>) {
+    pub unsafe fn show_context_menu_for_hwnd(
+        &mut self,
+        hwnd: isize,
+        position: Option<Position>,
+    ) -> bool {
         let rc = show_context_menu(hwnd as _, self.hpopupmenu, position);
         if let Some(item) = rc.and_then(|rc| self.find_by_id(rc)) {
-            menu_selected(hwnd as _, &mut item.borrow_mut());
+            unsafe {
+                menu_selected(hwnd as _, &mut item.borrow_mut());
+            }
+            return true;
         }
+        false
     }
 
     pub unsafe fn set_theme_for_hwnd(&self, hwnd: isize, theme: MenuTheme) -> crate::Result<()> {
@@ -921,13 +929,19 @@ impl MenuChild {
             .collect()
     }
 
-    pub unsafe fn show_context_menu_for_hwnd(&mut self, hwnd: isize, position: Option<Position>) {
+    pub unsafe fn show_context_menu_for_hwnd(
+        &mut self,
+        hwnd: isize,
+        position: Option<Position>,
+    ) -> bool {
         let rc = show_context_menu(hwnd as _, self.hpopupmenu, position);
         if let Some(item) = rc.and_then(|rc| self.find_by_id(rc)) {
             unsafe {
                 menu_selected(hwnd as _, &mut item.borrow_mut());
             }
+            return true;
         }
+        false
     }
 
     pub unsafe fn attach_menu_subclass_for_hwnd(&self, hwnd: isize) {


### PR DESCRIPTION
- Adding context menu dismiss result, so we would know the menu is dismissed because the user selected an item or canceled it.

- Windows, macOS
  -  Return `true` when item selected
  - Return `false` when the menu is canceled (including clicking on empty space, pressing ESC)
- Linux (Wayland)
  - Return `true` when an item is selected or clicking on empty space
  - Return `false` when the menu is canceled (like hitting ESC)

