### PR TITLE
fix: dont fire events for about menu item

### DIFF
--- a/.changes/about-macos-event.md
+++ b/.changes/about-macos-event.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+Fix `PredefinedMenuItem::about` sending events where it shouldn't.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -1036,14 +1036,14 @@ impl MenuItem {
                     };
                 }
             }
-        }
+        } else {
+            if item.item_type == MenuItemType::Check {
+                item.set_checked(!item.is_checked());
+            }
 
-        if item.item_type == MenuItemType::Check {
-            item.set_checked(!item.is_checked());
+            let id = (*item).id().clone();
+            MenuEvent::send(crate::MenuEvent { id });
         }
-
-        let id = (*item).id().clone();
-        MenuEvent::send(crate::MenuEvent { id });
     }
 
     fn create(


### PR DESCRIPTION
closes #215