### PR TITLE
feat: add `Accelerator::key` and `Accelerator::modifiers` getters

### DIFF
--- a/.changes/expose-modifiers-and-key-on-accelerator.md
+++ b/.changes/expose-modifiers-and-key-on-accelerator.md
@@ -1,0 +1,5 @@
+---
+"muda": minor
+---
+
+Expose `modifiers()` and `key()` on `Accelerator` immutably, to be able to inspect what was set on an `Accelerator`.

--- a/.changes/expose-modifiers-and-key-on-accelerator.md
+++ b/.changes/expose-modifiers-and-key-on-accelerator.md
@@ -2,4 +2,4 @@
 "muda": minor
 ---
 
-Expose `modifiers()` and `key()` on `Accelerator` immutably, to be able to inspect what was set on an `Accelerator`.
+Add `Accelerator::modifiers` and `Accelerator::key` getter methods.

--- a/.changes/expose-modifiers-and-key-on-accelerator.md
+++ b/.changes/expose-modifiers-and-key-on-accelerator.md
@@ -1,5 +1,5 @@
 ---
-"muda": minor
+"muda": patch
 ---
 
 Add `Accelerator::modifiers` and `Accelerator::key` getter methods.

--- a/src/accelerator.rs
+++ b/src/accelerator.rs
@@ -98,6 +98,16 @@ impl Accelerator {
         self.id
     }
 
+    /// Returns the modifier for this accelerator
+    pub fn modifiers(&self) -> Modifiers {
+        self.mods
+    }
+
+    /// Returns the code for this accelerator
+    pub fn key(&self) -> Code {
+        self.key
+    }
+
     /// Returns `true` if this [`Code`] and [`Modifiers`] matches this `Accelerator`.
     pub fn matches(&self, modifiers: impl Borrow<Modifiers>, key: impl Borrow<Code>) -> bool {
         // Should be a const but const bit_or doesn't work here.


### PR DESCRIPTION
This is a PR to expose the `Modifiers` and `Code` fields within an `Accelerator`, immutably. The types are public anyway, so I don't see why you shouldn't be able to inspect what you set earlier.

I personally need this to extract the modifiers and code and fill a human readable struct with them like so. I'm only using the `Accelerator` type from `muda` because it nicely represents hotkeys and supports string parsing.

```rust
struct Hotkey {
  shift: bool,
  alt: bool,
  control: bool,
  super: bool,
  key: Code,
}
```