### PR TITLE
fix(windows): buffer overflow when calling `text`

### DIFF
--- a/.changes/get-text-buffer-overflow.md
+++ b/.changes/get-text-buffer-overflow.md
@@ -1,0 +1,5 @@
+---
+muda: patch
+---
+
+Fix the buffer overflow when calling `text` on Windows

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -26,7 +26,7 @@ use std::{
 };
 use util::{decode_wide, encode_wide, Accel};
 use windows_sys::Win32::{
-    Foundation::{LPARAM, LRESULT, POINT, WPARAM},
+    Foundation::{FALSE, LPARAM, LRESULT, POINT, WPARAM},
     Graphics::Gdi::{ClientToScreen, HBITMAP},
     UI::{
         Input::KeyboardAndMouse::{
@@ -243,8 +243,8 @@ impl Menu {
                 let info = create_icon_item_info(hbitmap);
 
                 unsafe {
-                    SetMenuItemInfoW(self.hmenu, child_.internal_id, false.into(), &info);
-                    SetMenuItemInfoW(self.hpopupmenu, child_.internal_id, false.into(), &info);
+                    SetMenuItemInfoW(self.hmenu, child_.internal_id, FALSE, &info);
+                    SetMenuItemInfoW(self.hpopupmenu, child_.internal_id, FALSE, &info);
                 };
             }
         }
@@ -663,21 +663,18 @@ impl MenuChild {
         self.parents_hemnu
             .first()
             .map(|(hmenu, _)| {
-                let mut label = Vec::<u16>::new();
-
+                let id = self.internal_id();
                 let mut info: MENUITEMINFOW = unsafe { std::mem::zeroed() };
                 info.cbSize = std::mem::size_of::<MENUITEMINFOW>() as _;
                 info.fMask = MIIM_STRING;
-                info.dwTypeData = label.as_mut_ptr();
 
-                unsafe { GetMenuItemInfoW(*hmenu, self.internal_id(), false.into(), &mut info) };
-
-                let mut dw_type_data = Vec::with_capacity(info.cch as usize);
+                unsafe { GetMenuItemInfoW(*hmenu, id, FALSE, &mut info) };
 
                 info.cch += 1;
+                let mut dw_type_data = Vec::with_capacity(info.cch as usize);
                 info.dwTypeData = dw_type_data.as_mut_ptr();
 
-                unsafe { GetMenuItemInfoW(*hmenu, self.internal_id(), false.into(), &mut info) };
+                unsafe { GetMenuItemInfoW(*hmenu, id, FALSE, &mut info) };
 
                 let text = decode_wide(info.dwTypeData);
                 text.split('\t').next().unwrap().to_string()
@@ -699,7 +696,7 @@ impl MenuChild {
             info.fMask = MIIM_STRING;
             info.dwTypeData = text.as_mut_ptr();
 
-            unsafe { SetMenuItemInfoW(*parent, self.internal_id(), false.into(), &info) };
+            unsafe { SetMenuItemInfoW(*parent, self.internal_id(), FALSE, &info) };
 
             if let Some(menu_bars) = menu_bars {
                 for hwnd in menu_bars.borrow().keys() {
@@ -717,7 +714,7 @@ impl MenuChild {
                 info.cbSize = std::mem::size_of::<MENUITEMINFOW>() as _;
                 info.fMask = MIIM_STATE;
 
-                unsafe { GetMenuItemInfoW(*hmenu, self.internal_id(), false.into(), &mut info) };
+                unsafe { GetMenuItemInfoW(*hmenu, self.internal_id(), FALSE, &mut info) };
 
                 (info.fState & MFS_DISABLED) == 0
             })
@@ -765,7 +762,7 @@ impl MenuChild {
                 info.cbSize = std::mem::size_of::<MENUITEMINFOW>() as _;
                 info.fMask = MIIM_STATE;
 
-                unsafe { GetMenuItemInfoW(*hmenu, self.internal_id(), false.into(), &mut info) };
+                unsafe { GetMenuItemInfoW(*hmenu, self.internal_id(), FALSE, &mut info) };
 
                 (info.fState & MFS_CHECKED) != 0
             })
@@ -799,7 +796,7 @@ impl MenuChild {
             .unwrap_or(std::ptr::null_mut());
         let info = create_icon_item_info(hbitmap);
         for (parent, menu_bars) in &self.parents_hemnu {
-            unsafe { SetMenuItemInfoW(*parent, self.internal_id(), false.into(), &info) };
+            unsafe { SetMenuItemInfoW(*parent, self.internal_id(), FALSE, &info) };
 
             if let Some(menu_bars) = menu_bars {
                 for hwnd in menu_bars.borrow().keys() {
@@ -886,8 +883,8 @@ impl MenuChild {
                 let info = create_icon_item_info(hbitmap);
 
                 unsafe {
-                    SetMenuItemInfoW(self.hmenu, child_.internal_id, false.into(), &info);
-                    SetMenuItemInfoW(self.hpopupmenu, child_.internal_id, false.into(), &info);
+                    SetMenuItemInfoW(self.hmenu, child_.internal_id, FALSE, &info);
+                    SetMenuItemInfoW(self.hpopupmenu, child_.internal_id, FALSE, &info);
                 };
             }
         }


### PR DESCRIPTION
Fix https://github.com/tauri-apps/tauri/issues/12852

Reference [documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmenuiteminfow#remarks):

> To retrieve a menu item of type MFT_STRING, first find the size of the string by setting the dwTypeData member of [MENUITEMINFO](https://learn.microsoft.com/en-us/windows/desktop/api/winuser/ns-winuser-menuiteminfoa) to NULL and then calling GetMenuItemInfo. The value of cch+1 is the size needed. Then allocate a buffer of this size, place the pointer to the buffer in dwTypeData, increment cch by one, and then call GetMenuItemInfo once again to fill the buffer with the string.

The buffer needs to be `cch + 1`, not `cch` 😂

Also it says `dwTypeData` needs to be set to `NULL` while we set it to a valid pointer previously, this shouldn't matter but as it's not what the docs said, this PR also changes it to `NULL`