### PR TITLE
Make gtk an optional feature

### DIFF
--- a/.changes/gtk-feature.md
+++ b/.changes/gtk-feature.md
@@ -1,5 +1,5 @@
 ---
-"muda": major
+"muda": minor
 ---
 
 Make gtk an optional feature (enabled by default)

--- a/.changes/gtk-feature.md
+++ b/.changes/gtk-feature.md
@@ -1,0 +1,5 @@
+---
+"muda": major
+---
+
+Make gtk an optional feature (enabled by default)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ categories = ["gui"]
 rust-version = "1.71"
 
 [features]
-default = ["libxdo"]
+default = ["libxdo", "gtk"]
 libxdo = ["dep:libxdo"]
+gtk = ["dep:gtk"]
 common-controls-v6 = []
 serde = ["dep:serde", "dpi/serde"]
 
@@ -42,7 +43,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-gtk = "0.18"
+gtk = { version = "0.18", optional = true }
 libxdo = { version = "0.6.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Menu Utilities library for Desktop Applications.
 - `common-controls-v6`: Use `TaskDialogIndirect` API from `ComCtl32.dll` v6 on Windows for showing the predefined `About` menu item dialog.
 - `libxdo`: Enables linking to `libxdo` on Linux which is used for the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu item.
 - `serde`: Enables de/serializing the dpi types.
+- `gtk`: Enables the `gtk` crate dependency on Linux. This is required for `muda` to function properly on Linux.
 
 ## Dependencies (Linux Only)
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,13 +15,13 @@ pub enum Error {
     #[cfg(windows)]
     #[error("This menu has not been initialized for this hwnd`")]
     NotInitialized,
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     #[error("This menu has not been initialized for this gtk window`")]
     NotInitialized,
     #[cfg(windows)]
     #[error("This menu has already been initialized for this hwnd`")]
     AlreadyInitialized,
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     #[error("This menu has already been initialized for this gtk window`")]
     AlreadyInitialized,
     #[error(transparent)]

--- a/src/items/submenu.rs
+++ b/src/items/submenu.rs
@@ -233,7 +233,7 @@ impl ContextMenu for Submenu {
         self.inner.borrow().detach_menu_subclass_from_hwnd(hwnd)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     fn show_context_menu_for_gtk_window(
         &self,
         w: &gtk::Window,
@@ -244,7 +244,7 @@ impl ContextMenu for Submenu {
             .show_context_menu_for_gtk_window(w, position)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     fn gtk_context_menu(&self) -> gtk::Menu {
         self.inner.borrow_mut().gtk_context_menu()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ pub trait ContextMenu {
     /// Returns `true` if menu tracking ended because an item was selected or clicked outside the menu to dismiss it.
     ///
     /// Returns `false` if menu tracking was cancelled for any reason.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     fn show_context_menu_for_gtk_window(
         &self,
         w: &gtk::Window,
@@ -385,7 +385,7 @@ pub trait ContextMenu {
     /// Get the underlying gtk menu reserved for context menus.
     ///
     /// The returned [`gtk::Menu`] is valid as long as the `ContextMenu` is.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     fn gtk_context_menu(&self) -> gtk::Menu;
 
     /// Shows this menu as a context menu for the specified `NSView`.

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -182,7 +182,7 @@ impl Menu {
     /// ## Panics:
     ///
     /// Panics if the gtk event loop hasn't been initialized on the thread.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     pub fn init_for_gtk_window<W, C>(&self, window: &W, container: Option<&C>) -> crate::Result<()>
     where
         W: gtk::prelude::IsA<gtk::Window>,
@@ -270,7 +270,7 @@ impl Menu {
     }
 
     /// Removes this menu from a [`gtk::Window`]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     pub fn remove_for_gtk_window<W>(&self, window: &W) -> crate::Result<()>
     where
         W: gtk::prelude::IsA<gtk::Window>,
@@ -289,7 +289,7 @@ impl Menu {
     }
 
     /// Hides this menu from a [`gtk::Window`]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     pub fn hide_for_gtk_window<W>(&self, window: &W) -> crate::Result<()>
     where
         W: gtk::prelude::IsA<gtk::Window>,
@@ -308,7 +308,7 @@ impl Menu {
     }
 
     /// Shows this menu on a [`gtk::Window`]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     pub fn show_for_gtk_window<W>(&self, window: &W) -> crate::Result<()>
     where
         W: gtk::prelude::IsA<gtk::Window>,
@@ -327,7 +327,7 @@ impl Menu {
     }
 
     /// Returns whether this menu visible on a [`gtk::Window`]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     pub fn is_visible_on_gtk_window<W>(&self, window: &W) -> bool
     where
         W: gtk::prelude::IsA<gtk::Window>,
@@ -335,7 +335,7 @@ impl Menu {
         self.inner.borrow().is_visible_on_gtk_window(window)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     /// Returns the [`gtk::MenuBar`] that is associated with this window if it exists.
     /// This is useful to get information about the menubar for example its height.
     pub fn gtk_menubar_for_gtk_window<W>(self, window: &W) -> Option<gtk::MenuBar>
@@ -391,7 +391,7 @@ impl ContextMenu for Menu {
         self.inner.borrow().detach_menu_subclass_from_hwnd(hwnd)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     fn show_context_menu_for_gtk_window(
         &self,
         window: &gtk::Window,
@@ -402,7 +402,7 @@ impl ContextMenu for Menu {
             .show_context_menu_for_gtk_window(window, position)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gtk"))]
     fn gtk_context_menu(&self) -> gtk::Menu {
         self.inner.borrow_mut().gtk_context_menu()
     }

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -5,7 +5,7 @@
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
 mod platform;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "gtk"))]
 #[path = "gtk/mod.rs"]
 mod platform;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
This helps projects that uses muda on platform other than Linux to not get the gtk dependencies in their Cargo.lock (and the security advisories that goes with it)

Fixes https://github.com/tauri-apps/muda/issues/282