### PR TITLE
fix(linux): make mnemonic handling consistent across platforms

### DIFF
--- a/.changes/fix-mnemonics-linux.md
+++ b/.changes/fix-mnemonics-linux.md
@@ -2,10 +2,4 @@
 "muda": patch
 ---
 
-`&` and `_` in menu item labels are now handled on Linux the same way as
-on Windows:
-
-1. `&&` can be used for escaping and leads to a single displayed `&`.
-2. `_` is displayed as is and no longer causes a mnemonic. Escaping is not
-   needed.
-3. The back conversion of `_` works correctly.
+On Linux, fix `&&` resulting in `&&` when it should be just `&`. Also fix `_` not visible and actually adding a mnemonic. This makes the behavior on Linux match the behavior on Windows. 

--- a/.changes/fix-mnemonics-linux.md
+++ b/.changes/fix-mnemonics-linux.md
@@ -1,0 +1,11 @@
+---
+"muda": patch
+---
+
+`&` and `_` in menu item labels are now handled on Linux the same way as
+on Windows:
+
+1. `&&` can be used for escaping and leads to a single displayed `&`.
+2. `_` is displayed as is and no longer causes a mnemonic. Escaping is not
+   needed.
+3. The back conversion of `_` works correctly.

--- a/src/platform_impl/gtk/accelerator.rs
+++ b/src/platform_impl/gtk/accelerator.rs
@@ -10,18 +10,19 @@ use crate::accelerator::{Accelerator, AcceleratorParseError};
 pub fn to_gtk_mnemonic<S: AsRef<str>>(string: S) -> String {
     string
         .as_ref()
+        .replace("_", "__")
         .replace("&&", "[~~]")
         .replace('&', "_")
-        .replace("[~~]", "&&")
         .replace("[~~]", "&")
 }
 
 pub fn from_gtk_mnemonic<S: AsRef<str>>(string: S) -> String {
     string
         .as_ref()
+        .replace("&", "&&")
         .replace("__", "[~~]")
         .replace('_', "&")
-        .replace("[~~]", "__")
+        .replace("[~~]", "_")
 }
 
 pub fn parse_accelerator(


### PR DESCRIPTION
`&` and `_` in menu items are now handled on Linux the same way as on Windows.

1. `&&` can be used for escaping and leads to a single displayed `&`.
2. `_` is displayed as is and no longer causes a mnemonic. Escaping is not needed.
3. The back conversion of `_` works correctly.

Fixes #299