### PR TITLE
Exclude example files from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/amrbashir/muda"
 documentation = "https://docs.rs/muda"
 categories = ["gui"]
 rust-version = "1.71"
-include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT"]
+include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "LICENSE.spdx"]
 
 [features]
 default = ["libxdo", "gtk"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/amrbashir/muda"
 documentation = "https://docs.rs/muda"
 categories = ["gui"]
 rust-version = "1.71"
+include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [features]
 default = ["libxdo", "gtk"]


### PR DESCRIPTION
During our dependency reviews we discovered that the muda crate as uploaded to crates.io includes example data (a png)  that are not used by the rust code. This increases the package size and makes it harder to review the source code as it now includes binary data.

This commit explicitly includes only relevant files. This helps to reduce the package size

Before: 54 files, 482.0KiB (105.0KiB compressed)
After: 39 files, 416.9KiB (87.1KiB compressed)

Overall based on the reduction in the compressed package size and the current download numbers that results to a traffic reduction for crates.io of around 12GB / Month.