### PR TITLE
Fix padding unconditionally added to top-level submenus for icons even when there's no icon on Linux

### DIFF
--- a/.changes/fix-top-level-submenu-padding-issue.md
+++ b/.changes/fix-top-level-submenu-padding-issue.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+Fix padding unconditionally added to top-level submenus for icons even when there's no icon on Linux

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -130,8 +130,12 @@ impl Menu {
         return_if_item_not_supported!(item);
 
         for (menu_id, menu_bar) in self.gtk_menubars.iter().filter(|m| *m.0 == id) {
+            let has_icon = matches!(
+                item.kind(),
+                MenuItemKind::Submenu(submenu) if submenu.inner.borrow().icon.is_some()
+            );
             let gtk_item =
-                item.make_gtk_menu_item(*menu_id, self.accel_group.as_ref(), true, true)?;
+                item.make_gtk_menu_item(*menu_id, self.accel_group.as_ref(), true, has_icon)?;
             menu_bar.append(&gtk_item);
             gtk_item.show();
         }

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -761,14 +761,32 @@ impl MenuChild {
     pub fn set_icon(&mut self, icon: Option<Icon>) {
         self.icon.clone_from(&icon);
 
-        let pixbuf = icon.map(|i| i.inner.to_pixbuf_scale(16, 16));
+        let pixbuf = icon.as_ref().map(|i| i.inner.to_pixbuf_scale(16, 16));
         for items in self.gtk_menu_items.borrow().values() {
             for i in items {
                 let box_container = i.child().unwrap().downcast::<gtk::Box>().unwrap();
-                box_container.children()[0]
-                    .downcast_ref::<gtk::Image>()
-                    .unwrap()
-                    .set_pixbuf(pixbuf.as_ref())
+                let children = box_container.children();
+
+                // Check if the first child is an image (it might not be if the item
+                // was created for menu bar without an icon)
+                if let Some(image) = children
+                    .first()
+                    .and_then(|c| c.downcast_ref::<gtk::Image>())
+                {
+                    if icon.is_some() {
+                        // Image exists and we're setting an icon, update it
+                        image.set_pixbuf(pixbuf.as_ref());
+                    } else {
+                        // Image exists but we're removing the icon, remove the widget to avoid padding
+                        box_container.remove(image);
+                    }
+                } else if icon.is_some() {
+                    // No image widget exists yet, but we're setting an icon, so create one
+                    let image = gtk::Image::from_pixbuf(pixbuf.as_ref());
+                    box_container.pack_start(&image, false, false, 0);
+                    box_container.reorder_child(&image, 0);
+                    image.show();
+                }
             }
         }
     }

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -130,12 +130,8 @@ impl Menu {
         return_if_item_not_supported!(item);
 
         for (menu_id, menu_bar) in self.gtk_menubars.iter().filter(|m| *m.0 == id) {
-            let has_icon = matches!(
-                item.kind(),
-                MenuItemKind::Submenu(submenu) if submenu.inner.borrow().icon.is_some()
-            );
             let gtk_item =
-                item.make_gtk_menu_item(*menu_id, self.accel_group.as_ref(), true, has_icon)?;
+                item.make_gtk_menu_item(*menu_id, self.accel_group.as_ref(), true, true)?;
             menu_bar.append(&gtk_item);
             gtk_item.show();
         }
@@ -1031,7 +1027,9 @@ impl MenuChild {
             let _ = css_provider.load_from_data(theme.as_bytes());
             style_context.add_provider(&css_provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
-        box_container.pack_start(&image, false, false, 0);
+        if !for_menu_bar || self.icon.is_some() {
+            box_container.pack_start(&image, false, false, 0);
+        }
         box_container.pack_start(&label, true, true, 0);
         box_container.show_all();
 
@@ -1313,7 +1311,9 @@ impl MenuChild {
             let _ = css_provider.load_from_data(theme.as_bytes());
             style_context.add_provider(&css_provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
-        box_container.pack_start(&image, false, false, 0);
+        if !for_menu_bar || self.icon.is_some() {
+            box_container.pack_start(&image, false, false, 0);
+        }
         box_container.pack_start(&label, true, true, 0);
         box_container.show_all();
 

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -88,7 +88,7 @@ impl MenuItemKind {
         }
     }
 
-    pub(crate) fn child(&self) -> Ref<MenuChild> {
+    pub(crate) fn child(&self) -> Ref<'_, MenuChild> {
         match self {
             MenuItemKind::MenuItem(i) => i.inner.borrow(),
             MenuItemKind::Submenu(i) => i.inner.borrow(),
@@ -98,7 +98,7 @@ impl MenuItemKind {
         }
     }
 
-    pub(crate) fn child_mut(&self) -> RefMut<MenuChild> {
+    pub(crate) fn child_mut(&self) -> RefMut<'_, MenuChild> {
         match self {
             MenuItemKind::MenuItem(i) => i.inner.borrow_mut(),
             MenuItemKind::Submenu(i) => i.inner.borrow_mut(),


### PR DESCRIPTION
Currently, `muda` automatically reserves space for icons in top-level submenus; however, because of a bug that I've fixed in this PR, this was being done for all submenus, even if they didn't have icons.  See the screenshots below.

## Screenshots

|Before|After|
|---|---|
|<img width="1704" height="1304" alt="image" src="https://github.com/user-attachments/assets/15a07966-42f2-4e27-821f-f52a9c5c2498" />|<img width="1704" height="1304" alt="image (1)" src="https://github.com/user-attachments/assets/0e9574a7-33cd-414a-aa50-2684f33842a9" />|
