### PR TITLE
feat: Add predefined undo and redo menu item implementations for Windows

### DIFF
--- a/.changes/windows-redo-undo-predefined.md
+++ b/.changes/windows-redo-undo-predefined.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+Add support for `PredefinedMenuItem::undo` and `PredefinedMenuItem::redo` on Windows.

--- a/src/items/predefined.rs
+++ b/src/items/predefined.rs
@@ -63,7 +63,7 @@ impl PredefinedMenuItem {
     ///
     /// ## Platform-specific:
     ///
-    /// - **Windows / Linux:** Unsupported.
+    /// - **Linux:** Unsupported.
     pub fn undo(text: Option<&str>) -> PredefinedMenuItem {
         PredefinedMenuItem::new(PredefinedMenuItemType::Undo, text)
     }
@@ -71,7 +71,7 @@ impl PredefinedMenuItem {
     ///
     /// ## Platform-specific:
     ///
-    /// - **Windows / Linux:** Unsupported.
+    /// - **Linux:** Unsupported.
     pub fn redo(text: Option<&str>) -> PredefinedMenuItem {
         PredefinedMenuItem::new(PredefinedMenuItemType::Redo, text)
     }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1203,6 +1203,8 @@ unsafe fn menu_selected(hwnd: windows_sys::Win32::Foundation::HWND, item: &mut M
                         PredefinedMenuItemType::SelectAll => {
                             execute_edit_command(EditCommand::SelectAll)
                         }
+                        PredefinedMenuItemType::Undo => execute_edit_command(EditCommand::Undo),
+                        PredefinedMenuItemType::Redo => execute_edit_command(EditCommand::Redo),
                         PredefinedMenuItemType::Separator => {}
                         PredefinedMenuItemType::Minimize => {
                             ShowWindow(hwnd, SW_MINIMIZE);
@@ -1253,6 +1255,8 @@ enum EditCommand {
     Cut,
     Paste,
     SelectAll,
+    Undo,
+    Redo,
 }
 
 fn execute_edit_command(command: EditCommand) {
@@ -1261,6 +1265,8 @@ fn execute_edit_command(command: EditCommand) {
         EditCommand::Cut => 0x58,       // x
         EditCommand::Paste => 0x56,     // v
         EditCommand::SelectAll => 0x41, // a
+        EditCommand::Undo => 0x5A,      // z
+        EditCommand::Redo => 0x59,      // y
     };
 
     unsafe {


### PR DESCRIPTION
Simply adds the `Ctrl+Z` and `Ctrl+Y` keyboard shortcuts to the Windows implementations of the Undo and Redo predefined menu items.

Briefly tested as working on Windows 10.