### PR TITLE
fix(macos): render Return as ⏎ instead of ⌤

### DIFF
--- a/.changes/fix-macos-return-glyph.md
+++ b/.changes/fix-macos-return-glyph.md
@@ -1,0 +1,5 @@
+---
+"muda": "patch"
+---
+
+On macOS, render `Key::Enter` accelerators in menus as ⏎ (Return) instead of ⌤ (numeric-keypad Enter). Activation behavior is unchanged.

--- a/src/platform_impl/macos/accelerator.rs
+++ b/src/platform_impl/macos/accelerator.rs
@@ -14,7 +14,7 @@ impl KeyAccelerator {
             Key::Character(s) => s.clone(),
             Key::Tab => "⇥".into(),
             Key::Escape => "\u{001b}".into(),
-            Key::Enter => "\u{0003}".into(),
+            Key::Enter => "\u{000d}".into(),
             Key::Backspace => "\u{0008}".into(),
             Key::Delete => "\u{007f}".into(),
             Key::Insert => "\u{F727}".into(),


### PR DESCRIPTION
## Summary

On macOS, `Key::Enter` is currently mapped to `\u{0003}` (NSEnterCharacter), which AppKit renders as **⌤** in NSMenuItem accelerators. This is the glyph for the numeric‑keypad Enter key. Most macOS apps and Apple's HIG show **⏎** / **↩** for Return‑bound menu items.

This PR switches the mapping to `\u{000d}` (NSCarriageReturnCharacter) so AppKit renders the Return‑key glyph (**⏎**) instead.

```diff
-Key::Enter => "\u{0003}".into(),
+Key::Enter => "\u{000d}".into(),
```

### Behavior change

- **Display only.** Both `\u{0003}` and `\u{000d}` are matched by Return/Enter key events as a menu key equivalent, so menu activation behavior is unchanged.
- The change applies only to the macOS backend; other platforms are untouched.
- **Caveat for `Code::NumpadEnter`**: in `src/accelerator.rs` the legacy `Code::NumpadEnter` is normalized to `Key::Enter`, so accelerators built from `Accelerator(Code::NumpadEnter, …)` will now also be displayed as **⏎** rather than **⌤**. In other words, after this PR muda no longer emits the **⌤** glyph at all — main Return and numpad Enter were already indistinguishable in the displayed accelerator and remain so. This matches Apple's own apps, which use ⏎ for Return‑bound menu items regardless of which physical key the user presses.

### Why

Reported downstream as kohii/smoothcsv3#186 — the JS side of the keyboard‑shortcuts UI displayed **⏎** but the native context menu (rendered by muda) displayed **⌤** for the same Return‑bound menu item, leading users to think they were two different shortcuts.

### Screenshots (SmoothCSV, macOS)

| Before (⌘⌤) | After (⌘⏎) |
| --- | --- |
| <img width="714" height="190" alt="CleanShot 2026-05-09 at 15 23 20@2x" src="https://github.com/user-attachments/assets/b2e1c43f-b596-436f-9655-79d7142fd055" /> | <img width="724" height="184" alt="CleanShot 2026-05-09 at 15 22 54@2x" src="https://github.com/user-attachments/assets/6f071625-fcfe-40e2-a8f2-65466d6c9b00" /> |

### Reference

- AppKit's `NSText.h` defines both:
  - `NSCarriageReturnCharacter = 0x000D` → ⏎ (Return)
  - `NSEnterCharacter = 0x0003` → ⌤ (numpad Enter)
- Apple's HIG / [Apple Support: symbols shown in menus](https://support.apple.com/guide/mac-help/what-the-symbols-mean-cpmh0011/mac): ⏎/↩ for Return, ⌤ for Enter.

## Test plan

- [x] Verified locally in a Tauri 2.10.3 app (SmoothCSV) — context menu items bound to `cmd+enter` now display **⌘⏎**, matching the in‑app shortcut UI.
- [x] Return key still triggers the menu item.