### PR TITLE
fix(windows): prevent dark menubar item text truncation

### DIFF
--- a/.changes/fix-win-dark-menubar.md
+++ b/.changes/fix-win-dark-menubar.md
@@ -1,0 +1,5 @@
+---
+"muda": patch
+---
+
+On Windows, fixed a bug that would truncate menubar items text to ~10 characters in dark-mode.

--- a/src/platform_impl/windows/dark_menu_bar.rs
+++ b/src/platform_impl/windows/dark_menu_bar.rs
@@ -175,13 +175,10 @@ pub fn draw(hwnd: super::Hwnd, msg: u32, _wparam: WPARAM, lparam: LPARAM) {
 
             // get the menu item string
             let (label, cch) = {
-                let mut label = Vec::<u16>::with_capacity(256);
                 let mut info: MENUITEMINFOW = unsafe { std::mem::zeroed() };
                 info.cbSize = std::mem::size_of::<MENUITEMINFOW>() as _;
                 info.fMask = MIIM_STRING;
-                info.dwTypeData = label.as_mut_ptr();
-                info.cch = (std::mem::size_of_val(&label) / 2 - 1) as _;
-                unsafe {
+                let ok = unsafe {
                     GetMenuItemInfoW(
                         (*pudmi).um.hmenu,
                         (*pudmi).umi.iPosition,
@@ -189,6 +186,26 @@ pub fn draw(hwnd: super::Hwnd, msg: u32, _wparam: WPARAM, lparam: LPARAM) {
                         &mut info,
                     )
                 };
+                if ok == 0 {
+                    return;
+                }
+
+                info.cch += 1; // add 1 for null terminator
+                let mut label = vec![0u16; info.cch as usize];
+                info.dwTypeData = label.as_mut_ptr();
+
+                let ok = unsafe {
+                    GetMenuItemInfoW(
+                        (*pudmi).um.hmenu,
+                        (*pudmi).umi.iPosition,
+                        true.into(),
+                        &mut info,
+                    )
+                };
+                if ok == 0 {
+                    return;
+                }
+
                 (label, info.cch)
             };
 


### PR DESCRIPTION
The dark menubar draw path fetched menu item text with an incorrectly sized UTF-16 buffer, which truncated top-level labels during custom drawing in dark mode. Previously it used `size_of_val(&label)`, which returned the size of the Vec struct itself rather than its contents and limited retrieval to about 10 UTF-16 code units on 64-bit Windows.

Use the standard two-step GetMenuItemInfoW pattern: first query the required string length, then allocate a buffer large enough for the full label plus the trailing null terminator before fetching the text.

Also returns early if either Win32 call fails so the draw path skips the label instead of using incomplete data.

**Before:**
<img width="230" height="113" alt="image" src="https://github.com/user-attachments/assets/383b589c-1522-4442-867a-c03e1e86a7d9" />

**After:**
<img width="235" height="114" alt="image" src="https://github.com/user-attachments/assets/c5e5e048-a16a-4a89-b6f7-c62abf623037" />